### PR TITLE
Export `Extractor` instead of `extract`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
 module.exports = {
     compile: require('./lib/compile'),
-    extract: require('./lib/extract'),
+    Extractor: require('./lib/extract')
 };


### PR DESCRIPTION
extract.js exports a class called `Extractor`, not a function.
