### PR TITLE
fix jshint warning for UTF-8 symbols that are uncommon - e.g. non-latin ...

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -7,7 +7,7 @@ var formats = {
             return "    gettextCatalog.setStrings('" + locale + "', " + (JSON.stringify(strings)) + ");\n";
         },
         format: function (locales, options) {
-            return "angular.module(\"" + options.module + "\").run(['gettextCatalog', function (gettextCatalog) {\n" + locales.join('') + "\n}]);";
+            return "angular.module(\"" + options.module + "\").run(['gettextCatalog', function (gettextCatalog) {\n/* jshint -W100 */\n" + locales.join('') + "\n/* jshint +W100 */\n}]);";
         }
     },
     json: {
@@ -56,7 +56,7 @@ var Compiler = (function () {
             locales.push(format.addLocale(catalog.headers.Language, strings));
 
         });
-        
+
         return format.format(locales, this.options);
     };
 


### PR DESCRIPTION
...alphabets
