### PR TITLE
No need for a new line before /* jshint +W100 */

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -7,7 +7,7 @@ var formats = {
             return "    gettextCatalog.setStrings('" + locale + "', " + JSON.stringify(strings) + ");\n";
         },
         format: function (locales, options) {
-            return "angular.module('" + options.module + "').run(['gettextCatalog', function (gettextCatalog) {\n/* jshint -W100 */\n" + locales.join('') + "\n/* jshint +W100 */\n}]);";
+            return "angular.module('" + options.module + "').run(['gettextCatalog', function (gettextCatalog) {\n/* jshint -W100 */\n" + locales.join('') + "/* jshint +W100 */\n}]);";
         }
     },
     json: {


### PR DESCRIPTION
Small fix.

Instead of:

``` JavaScript
angular.module('gettext').run(['gettextCatalog', function (gettextCatalog) {
/* jshint -W100 */
    gettextCatalog.setStrings('en', ...);

/* jshint +W100 */
}]);
```

Now generates:

``` JavaScript
angular.module('gettext').run(['gettextCatalog', function (gettextCatalog) {
/* jshint -W100 */
    gettextCatalog.setStrings('en', ...);
/* jshint +W100 */
}]);
```

(I know, it's futile :) )
