### PR TITLE
Add support for Rails' ERB templates

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -53,6 +53,7 @@ var Extractor = (function () {
                 php: 'html',
                 phtml: 'html',
                 tml: 'html',
+                erb: 'html',
                 js: 'js'
             },
             postProcess: function (po) {}


### PR DESCRIPTION
Presently they're not being detected because the extension is not listed and Extractor tries to parse it as a JS file. With this change, it detects the `translate` directives fine because ERB templates look just like PHP.
