### PR TITLE
fixed a comment bug in JS files

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -89,7 +89,7 @@ var Extractor = (function () {
             item.msgid_plural = plural;
             item.msgstr = ['', ''];
         }
-        if (extractedComment && extractedComment !== '') {
+        if (extractedComment && extractedComment.length > 0) {
             item.extractedComments.push(extractedComment);
         }
     };
@@ -150,8 +150,8 @@ var Extractor = (function () {
             if (str || singular) {
                 if (parentComment) {
                     parentComment.leadingComments.forEach(function (comment) {
-                        if (comment.value.match(/\/ .*/)) {
-                            extractedComments.push(comment.value.replace(/\//, ''));
+                        if (comment.value.match(/^\/ .*/)) {
+                            extractedComments.push(comment.value.replace(/^\/ /, ''));
                         }
                     });
                 }

--- a/test/extract.coffee
+++ b/test/extract.coffee
@@ -91,17 +91,19 @@ describe 'Extract', ->
 
         i = catalog.items
 
-        assert.equal(i.length, 3)
+        assert.equal(i.length, 4)
 
         assert.equal(i[0].msgid, 'Bird')
         assert.equal(i[0].extractedComments, 'Plural Comments')
 
-        assert.equal(i[1].msgid, 'Translate this')
-        assert.equal(i[1].extractedComments, 'This is a comment')
+        assert.equal(i[1].msgid, 'No comment')
+        assert.equal(i[1].extractedComments, '')
 
-        assert.equal(i[2].msgid, 'Two Part Comment')
-        assert.equal(i[2].extractedComments, 'This is two part comment, Second part')
+        assert.equal(i[2].msgid, 'Translate this')
+        assert.equal(i[2].extractedComments, 'This is a comment')
 
+        assert.equal(i[3].msgid, 'Two Part Comment')
+        assert.equal(i[3].extractedComments, 'This is two part comment,Second part')
 
     it 'Merges singular and plural strings', ->
         files = [

--- a/test/fixtures/comments.js
+++ b/test/fixtures/comments.js
@@ -6,6 +6,14 @@ angular.module("myApp").controller("helloController", function (gettext, gettext
     /// Second part
     var myString = gettext("Two Part Comment");
 
+	/**
+	* Please ignore this comment ///gettext
+	  Thank You
+	*/
+    var myString = gettext("No comment");
+
     /// Plural Comments
     var myString = gettextCatalog.getPlural(2, "Bird", "Birds");
+
+    /// Comment with no translations, ignore this comment too
 });


### PR DESCRIPTION
Hi,

I noticed there was a bug in my change, please take look at the following notes:

The extractor was extracing the following:

``` javascript
angular.module("myApp").controller("helloController", function (gettext, gettextCatalog) {
    /**
     * Ignore this comment / thank you
    */
    var myString = gettext("String with no comments");
});
```

as 

``` po
#.
  * Ignore this comment / thank you
    */
msgid "String with no comments"
msgstr ""
```

**Changes made**:
- Fixed the regex to look for match only at the start of the string, 

``` javascript
    // Old Regex
    comment.value.match(/\/ .*/)
    // New Regex
    comment.value.match(/^\/ .*/)
```
- Fixed the empty comments picked up by extractor(only in JS files), even though no comment was inserted.

**Before**

``` po
#.
msgid "String with no comments"
msgstr ""
```

**After**

``` po
msgid "String with no comments"
msgstr ""
```
- Added another sub-testcase to make sure multi-line comments do not break the extractor

Sorry about that, thanks!
