### PR TITLE
Extract filters from objects and expression

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -10,10 +10,14 @@ var mkAttrRegex = function (startDelim, endDelim) {
     var end = endDelim.replace(escapeRegex, '\\$&');
 
     if (start === '' && end === '') {
-        start = '^';
+        start = '^\\s*';
+        end = '\\s*';
+    } else {
+        start = start + '.*?';
+        end = '.*?' + end;
     }
 
-    return new RegExp(start + '\\s*(\'|"|&quot;)(.*?)\\1\\s*\\|\\s*translate\\s*(' + end + '|\\|)', 'g');
+    return new RegExp(start + '(\'|"|&quot;)(.*?)\\1\\s*\\|\\s*translate(' + end + '|\\|)', 'g');
 };
 
 var noDelimRegex = mkAttrRegex('', '');

--- a/test/extract_regex.coffee
+++ b/test/extract_regex.coffee
@@ -65,6 +65,58 @@ describe 'Extract: Filter regex', ->
 
         assert.equal(hit, 2)
 
+    it 'Matches filters in complex objects', ->
+        hit = false
+        while matches = regex.exec("{{ {first: ('Hello'|translate)} }}")
+            assert.equal(matches.length, 4)
+            assert.equal(matches[2], 'Hello')
+            hit = true
+
+        assert(hit)
+
+    it 'Matches filters in JSON', ->
+        hit = false
+        while matches = regex.exec("{{ {\"first\": ('Hello'|translate)} }}")
+            assert.equal(matches.length, 4)
+            assert.equal(matches[2], 'Hello')
+            hit = true
+
+        assert(hit)
+
+    it 'Does not match JSON with same quotes as property name', ->
+        hit = false
+        # Unable to match with regexp {'first': ('Hello'|translate)}
+        while matches = regex.exec("{{ {'first': ('Hello'|translate)} }}")
+            assert.equal(matches.length, 4)
+            assert.equal(matches[2], 'first\': (\'Hello')
+            hit = true
+
+        assert(hit)
+
+
+    it 'Matches filters in expressions', ->
+        hit = 0
+        while matches = regex.exec("{{ a==b ? 'Hello'|translate : 'empty' }}")
+            if hit == 0
+                assert.equal(matches.length, 4)
+                assert.equal(matches[2], 'Hello')
+            hit++
+
+        assert.equal(hit, 1)
+
+    it 'Matches multiple filters in expressions', ->
+        hit = 0
+        while matches = regex.exec("{{ a==b ? 'Hello'|translate : 'Second'|translate }}")
+            if hit == 0
+                assert.equal(matches.length, 4)
+                assert.equal(matches[2], 'Hello')
+            else if hit == 1
+                assert.equal(matches.length, 4)
+                assert.equal(matches[2], 'Second')
+            hit++
+
+        assert.equal(hit, 1)
+
     it 'Matches encoded quotes', ->
         hit = 0
         while matches = regex.exec("{{'Hello'|translate}} {{&quot;Second&quot;|translate}}")
@@ -133,7 +185,7 @@ describe 'Extract: Filter regex', ->
             assert.equal(matches[2], 'Hello')
             hit = true
         assert(hit)
-        
+
     it 'Can be used without delimiters with multiple filters', ->
         regex = mkAttrRegex('', '')
         hit = false
@@ -141,7 +193,7 @@ describe 'Extract: Filter regex', ->
             assert.equal(matches.length, 4)
             assert.equal(matches[2], 'Hello')
             hit = true
-        assert(hit)        
+        assert(hit)
 
         matches = regex.exec("{{'Hello' | translate}}")
         assert.equal(matches, null)


### PR DESCRIPTION
It would be nice to be able to extract filters from expressions and object literals.
Like this:

```
<input placeholder="{{ a==b ? 'Hello'|translate : 0 }}"
```

and this

```
<input placeholder="{{ {first: ('Hello'|translate)} }}"
```

But I have some troubles with objects like this:

```
{{ {'first': ('Hello'|translate)} }}
```

Looks like it's impossible to write correct regexp without changing groups order.
