### PR TITLE
Check for deeper getString() call paths

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -115,8 +115,11 @@ var Extractor = (function () {
                 node.type === 'CallExpression' &&
                 node.callee !== null &&
                 node.callee.type === 'MemberExpression' &&
-                node.callee.object !== null &&
-                node.callee.object.name === 'gettextCatalog' &&
+                node.callee.object !== null && (
+                    node.callee.object.name === 'gettextCatalog' || (
+                        // also allow gettextCatalog calls on objects like this.gettextCatalog.getString()
+                        node.callee.object.property &&
+                        node.callee.object.property.name === 'gettextCatalog')) &&
                 node.callee.property !== null &&
                 node.callee.property.name === 'getString' &&
                 node.arguments !== null &&
@@ -128,8 +131,11 @@ var Extractor = (function () {
                 node.type === 'CallExpression' &&
                 node.callee !== null &&
                 node.callee.type === 'MemberExpression' &&
-                node.callee.object !== null &&
-                node.callee.object.name === 'gettextCatalog' &&
+                node.callee.object !== null && (
+		    node.callee.object.name === 'gettextCatalog' || (
+                        // also allow gettextCatalog calls on objects like this.gettextCatalog.getPlural()
+                        node.callee.object.property &&
+                        node.callee.object.property.name === 'gettextCatalog')) &&
                 node.callee.property !== null &&
                 node.callee.property.name === 'getPlural' &&
                 node.arguments !== null &&

--- a/test/extract.coffee
+++ b/test/extract.coffee
@@ -192,6 +192,25 @@ describe 'Extract', ->
         assert.equal(catalog.items[1].references.length, 1)
         assert.equal(catalog.items[1].references[0], 'test/fixtures/catalog.js')
 
+    it 'Extracts strings from deep path calls to obj.gettextCatalog', ->
+        files = [
+            'test/fixtures/deeppath_catalog.js'
+        ]
+        catalog = testExtract(files)
+
+        assert.equal(catalog.items[0].msgid, 'Bird')
+        assert.equal(catalog.items[0].msgid_plural, 'Birds')
+        assert.equal(catalog.items[0].msgstr.length, 2)
+        assert.equal(catalog.items[0].msgstr[0], '')
+        assert.equal(catalog.items[0].msgstr[1], '')
+        assert.equal(catalog.items[0].references.length, 1)
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/deeppath_catalog.js')
+        assert.equal(catalog.items.length, 2)
+        assert.equal(catalog.items[1].msgid, 'Hello')
+        assert.equal(catalog.items[1].msgstr, '')
+        assert.equal(catalog.items[1].references.length, 1)
+        assert.equal(catalog.items[1].references[0], 'test/fixtures/deeppath_catalog.js')
+
     it 'Extracts strings with quotes', ->
         files = [
             'test/fixtures/quotes.html'

--- a/test/fixtures/deeppath_catalog.js
+++ b/test/fixtures/deeppath_catalog.js
@@ -1,0 +1,6 @@
+angular.module("myApp").controller("helloController", function (gettextCatalog) {
+    var obj = {
+        gettextCatalog: gettextCatalog };
+    var myString = obj.gettextCatalog.getString("Hello");
+    var myString2 = obj.gettextCatalog.getPlural(3, "Bird", "Birds");
+});


### PR DESCRIPTION
Allow calling of this.gettextCatalog.getString(), not just direct access of gettextCatalog.getString().

We were injecting gettextCatalog in our angular controller and storing it in the class, without this change we would have to reassign it to a var each time we want to access getString(). This change detects longer call paths, as long as the last part is gettextCatalog.getString().
