### PR TITLE
Added line numbers after filenames for javascript files

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -70,7 +70,7 @@ var Extractor = (function () {
 
     Extractor.mkAttrRegex = mkAttrRegex;
 
-    Extractor.prototype.addString = function (file, string, plural, extractedComment) {
+    Extractor.prototype.addString = function (location, string, plural, extractedComment) {
         string = string.trim();
 
         if (!this.strings[string]) {
@@ -79,8 +79,8 @@ var Extractor = (function () {
 
         var item = this.strings[string];
         item.msgid = string;
-        if (item.references.indexOf(file) < 0) {
-            item.references.push(file);
+        if (item.references.indexOf(location) < 0) {
+            item.references.push(location);
         }
         if (plural && plural !== '') {
             if (item.msgid_plural && item.msgid_plural !== plural) {
@@ -98,17 +98,15 @@ var Extractor = (function () {
         var self = this;
         var syntax = esprima.parse(src, {
             tolerant: true,
-            attachComment: true
+            attachComment: true,
+            loc: true
         });
 
         function isGettext(node) {
             return node !== null &&
                 node.type === 'CallExpression' &&
                 node.callee !== null &&
-                (node.callee.name === self.options.markerName || (
-                    node.callee.property &&
-                    node.callee.property.name === self.options.markerName
-                )) &&
+                node.callee.name === self.options.markerName &&
                 node.arguments !== null &&
                 node.arguments.length;
         }
@@ -164,10 +162,12 @@ var Extractor = (function () {
                         }
                     });
                 }
+
+                var location = filename + ':' + node.loc.start.line;
                 if (str) {
-                    self.addString(filename, str, plural, extractedComments);
+                    self.addString(location, str, plural, extractedComments);
                 } else if (singular) {
-                    self.addString(filename, singular, plural, extractedComments);
+                    self.addString(location, singular, plural, extractedComments);
                 }
             }
         });


### PR DESCRIPTION
This adds line numbers for the references to javascript files. Supporting HTML files is not as simple, because _Cheerio_ does not provide line numbers in its API like _Esprima_ does.

I haven't created or touched any unit tests, as this was something I did to scratch my own itch, but I'm sharing it in case it could be useful to others.
