### PR TITLE
Make catalog name and catalog accessor function name customizable

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -3,17 +3,17 @@ var _ = require('lodash');
 
 var formats = {
     javascript: {
-        addLocale: function (locale, strings) {
-            return '    gettextCatalog.setStrings(\'' + locale + '\', ' + JSON.stringify(strings) + ');\n';
+        addLocale: function (locale, strings, options) {
+            return '    ' + options.catalogMarkerName + '.' + options.catalogAccessorName + '(\'' + locale + '\', ' + JSON.stringify(strings) + ');\n';
         },
         format: function (locales, options) {
             var module = 'angular.module(\'' + options.module + '\')' +
-                            '.run([\'gettextCatalog\', function (gettextCatalog) {\n' +
-                                '/* jshint -W100 */\n' +
-                                locales.join('') +
-                                '/* jshint +W100 */\n';
+                '.run([\'' + options.catalogMarkerName + '\', function (' + options.catalogMarkerName + ') {\n' +
+                '/* jshint -W100 */\n' +
+                locales.join('') +
+                '/* jshint +W100 */\n';
             if (options.defaultLanguage) {
-                module += 'gettextCatalog.currentLanguage = \'' + options.defaultLanguage + '\';\n';
+                module += options.catalogMarkerName + '.currentLanguage = \'' + options.defaultLanguage + '\';\n';
             }
             module += '}]);';
 
@@ -48,7 +48,9 @@ var Compiler = (function () {
     function Compiler(options) {
         this.options = _.extend({
             format: 'javascript',
-            module: 'gettext'
+            module: 'gettext',
+            catalogMarkerName: 'gettextCatalog',
+            catalogAccessorName: 'setStrings'
         }, options);
     }
 
@@ -60,6 +62,7 @@ var Compiler = (function () {
         var format = formats[this.options.format];
         var locales = [];
 
+        var self = this;
         inputs.forEach(function (input) {
             var catalog = po.parse(input);
 
@@ -75,7 +78,7 @@ var Compiler = (function () {
                 }
             }
 
-            locales.push(format.addLocale(catalog.headers.Language, strings));
+            locales.push(format.addLocale(catalog.headers.Language, strings, self.options));
 
         });
 

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -50,6 +50,9 @@ var Extractor = (function () {
             startDelim: '{{',
             endDelim: '}}',
             markerName: 'gettext',
+            catalogMarkerName: 'gettextCatalog',
+            catalogAccessorName: 'getString',
+            catalogPluralAccessorName: 'getPlural',
             extensions: {
                 htm: 'html',
                 html: 'html',
@@ -119,12 +122,12 @@ var Extractor = (function () {
                 node.callee !== null &&
                 node.callee.type === 'MemberExpression' &&
                 node.callee.object !== null && (
-                    node.callee.object.name === 'gettextCatalog' || (
-                        // also allow gettextCatalog calls on objects like this.gettextCatalog.getString()
-                        node.callee.object.property &&
-                        node.callee.object.property.name === 'gettextCatalog')) &&
+                node.callee.object.name === self.options.catalogMarkerName || (
+                // also allow gettextCatalog calls on objects like this.gettextCatalog.getString()
+                node.callee.object.property &&
+                node.callee.object.property.name === self.options.catalogMarkerName)) &&
                 node.callee.property !== null &&
-                node.callee.property.name === 'getString' &&
+                node.callee.property.name === self.options.catalogAccessorName &&
                 node.arguments !== null &&
                 node.arguments.length;
         }
@@ -135,12 +138,12 @@ var Extractor = (function () {
                 node.callee !== null &&
                 node.callee.type === 'MemberExpression' &&
                 node.callee.object !== null && (
-		    node.callee.object.name === 'gettextCatalog' || (
-                        // also allow gettextCatalog calls on objects like this.gettextCatalog.getPlural()
-                        node.callee.object.property &&
-                        node.callee.object.property.name === 'gettextCatalog')) &&
+                node.callee.object.name === self.options.catalogMarkerName || (
+                // also allow gettextCatalog calls on objects like this.gettextCatalog.getPlural()
+                node.callee.object.property &&
+                node.callee.object.property.name === self.options.catalogMarkerName)) &&
                 node.callee.property !== null &&
-                node.callee.property.name === 'getPlural' &&
+                node.callee.property.name === self.options.catalogPluralAccessorName &&
                 node.arguments !== null &&
                 node.arguments.length;
         }

--- a/test/extract.coffee
+++ b/test/extract.coffee
@@ -213,6 +213,50 @@ describe 'Extract', ->
         assert.equal(catalog.items[1].references.length, 1)
         assert.equal(catalog.items[1].references[0], 'test/fixtures/catalog.js')
 
+    it 'Extracts strings using custom catalog name and default accessor name', ->
+        files = [
+            'test/fixtures/custom_catalog.js'
+        ]
+        catalog = testExtract(files, {
+            catalogMarkerName: 'myGettextCatalog'
+        });
+
+        assert.equal(catalog.items[0].msgid, 'Bird')
+        assert.equal(catalog.items[0].msgid_plural, 'Birds')
+        assert.equal(catalog.items[0].msgstr.length, 2)
+        assert.equal(catalog.items[0].msgstr[0], '')
+        assert.equal(catalog.items[0].msgstr[1], '')
+        assert.equal(catalog.items[0].references.length, 1)
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/custom_catalog.js')
+        assert.equal(catalog.items.length, 2)
+        assert.equal(catalog.items[1].msgid, 'Hello')
+        assert.equal(catalog.items[1].msgstr, '')
+        assert.equal(catalog.items[1].references.length, 1)
+        assert.equal(catalog.items[1].references[0], 'test/fixtures/custom_catalog.js')
+
+    it 'Extracts strings using custom catalog name and custom accessor name', ->
+        files = [
+            'test/fixtures/custom_catalog_and_accessors.js'
+        ]
+        catalog = testExtract(files, {
+            catalogMarkerName: 'myGettextCatalog'
+            catalogAccessorName: 'getTranslation'
+            catalogPluralAccessorName: 'getPluralTranslation'
+        })
+
+        assert.equal(catalog.items[0].msgid, 'Bird')
+        assert.equal(catalog.items[0].msgid_plural, 'Birds')
+        assert.equal(catalog.items[0].msgstr.length, 2)
+        assert.equal(catalog.items[0].msgstr[0], '')
+        assert.equal(catalog.items[0].msgstr[1], '')
+        assert.equal(catalog.items[0].references.length, 1)
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/custom_catalog_and_accessors.js')
+        assert.equal(catalog.items.length, 2)
+        assert.equal(catalog.items[1].msgid, 'Hello')
+        assert.equal(catalog.items[1].msgstr, '')
+        assert.equal(catalog.items[1].references.length, 1)
+        assert.equal(catalog.items[1].references[0], 'test/fixtures/custom_catalog_and_accessors.js')
+
     it 'Extracts strings from deep path calls to obj.gettextCatalog', ->
         files = [
             'test/fixtures/deeppath_catalog.js'

--- a/test/fixtures/custom_catalog.js
+++ b/test/fixtures/custom_catalog.js
@@ -1,0 +1,4 @@
+angular.module("myApp").controller("helloController", function (myGettextCatalog) {
+    var myString = myGettextCatalog.getString("Hello");
+    var myString2 = myGettextCatalog.getPlural(3, "Bird", "Birds");
+});

--- a/test/fixtures/custom_catalog_and_accessors.js
+++ b/test/fixtures/custom_catalog_and_accessors.js
@@ -1,0 +1,4 @@
+angular.module("myApp").controller("helloController", function (myGettextCatalog) {
+    var myString = myGettextCatalog.getTranslation("Hello");
+    var myString2 = myGettextCatalog.getPluralTranslation(3, "Bird", "Birds");
+});


### PR DESCRIPTION
Hi,

the project I am currently working for requires the gettext catalog name and accessor function name to be customizable through configuration parameters in order to avoid coupling to the API of angular-gettext. What we like to do is something like this:

Grunt Config:

```
nggettext_extract: {
    pot: {
        options: {
            markerName: 'translate',
            catalogMarkerName: 'i18nService',
            catalogAccessorName: 'getTranslation',
            catalogAccessorPluralName: 'getPluralTranslation'
        },
        files: {
            'po/template.pot': ['src/app/**/*.html', 'src/app/**/*.js']
        }
    }
},
nggettext_compile: {
    all: {
        options: {
            module: 'app',
            catalogMarkerName: 'i18nService',
            catalogAccessorName: 'setTranslations'
        },
        files: {
            'src/app/translations.js': ['po/*.po']
        }
    }
}
```

AngularJS Code:

```
angular.module("myApp").controller("helloController", function (i18nService) {
    var myString = i18nService.getTranslation("Hello");
    var myString2 = i18nService.getPluralTranslation(3, "Bird", "Birds");
});
```

In order to get access to the translated strings in AngularJS we will create a wrapper around angular-gettext which simply forwards the calls to gettextCatalog.getString, gettextCatalog.getPlural, ...
Using this approach we are completely independent from the angular-gettext API and can even interchange our internationalisation provider if the need arises.

Thanks for checking my modifications and for your feedback!

Cheers Andi
