### PR TITLE
Extract line numbers from JavaScript

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -51,6 +51,7 @@ var Extractor = (function () {
             endDelim: '}}',
             markerName: 'gettext',
             markerNames: [],
+            lineNumbers: true,
             extensions: {
                 htm: 'html',
                 html: 'html',
@@ -72,7 +73,12 @@ var Extractor = (function () {
 
     Extractor.mkAttrRegex = mkAttrRegex;
 
-    Extractor.prototype.addString = function (file, string, plural, extractedComment) {
+    Extractor.prototype.addString = function (reference, string, plural, extractedComment) {
+        // maintain backwards compatibility
+        if (_.isString(reference)) {
+            reference = { file: reference };
+        }
+
         string = string.trim();
 
         if (string.length === 0) {
@@ -85,8 +91,17 @@ var Extractor = (function () {
 
         var item = this.strings[string];
         item.msgid = string;
-        if (item.references.indexOf(file) < 0) {
-            item.references.push(file);
+
+        var refString = reference.file;
+        if (this.options.lineNumbers && reference.location && reference.location.start) {
+            var line = reference.location.start.line;
+            if (line || line === 0) {
+                refString += ':' + reference.location.start.line;
+            }
+        }
+
+        if (item.references.indexOf(refString) < 0) {
+            item.references.push(refString);
         }
         if (plural && plural !== '') {
             if (item.msgid_plural && item.msgid_plural !== plural) {
@@ -104,7 +119,8 @@ var Extractor = (function () {
         var self = this;
         var syntax = esprima.parse(src, {
             tolerant: true,
-            attachComment: true
+            attachComment: true,
+            loc: true
         });
 
         function isGettext(node) {
@@ -156,6 +172,8 @@ var Extractor = (function () {
             var singular;
             var plural;
             var extractedComments = [];
+            var reference = { file: filename, location: node ? node.loc : null };
+
             if (isGettext(node) || isGetString(node)) {
                 str = getJSExpression(node.arguments[0]);
             } else if (isGetPlural(node)) {
@@ -170,9 +188,9 @@ var Extractor = (function () {
                     }
                 });
                 if (str) {
-                    self.addString(filename, str, plural, extractedComments);
+                    self.addString(reference, str, plural, extractedComments);
                 } else if (singular) {
-                    self.addString(filename, singular, plural, extractedComments);
+                    self.addString(reference, singular, plural, extractedComments);
                 }
             }
         });

--- a/test/extract.coffee
+++ b/test/extract.coffee
@@ -196,7 +196,7 @@ describe 'Extract', ->
         assert.equal(catalog.items[0].msgid, 'Hello')
         assert.equal(catalog.items[0].msgstr, '')
         assert.equal(catalog.items[0].references.length, 1)
-        assert.equal(catalog.items[0].references[0], 'test/fixtures/source.js')
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/source.js:2')
 
     it 'Extracts flagged strings from OOP Javascript source', ->
         files = [
@@ -213,11 +213,11 @@ describe 'Extract', ->
         assert.equal(catalog.items[2].msgstr, '')
 
         assert.equal(catalog.items[0].references.length, 1)
-        assert.equal(catalog.items[0].references[0], 'test/fixtures/source-property.js')
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/source-property.js:5')
         assert.equal(catalog.items[1].references.length, 1)
-        assert.equal(catalog.items[1].references[0], 'test/fixtures/source-property.js')
+        assert.equal(catalog.items[1].references[0], 'test/fixtures/source-property.js:11')
         assert.equal(catalog.items[2].references.length, 1)
-        assert.equal(catalog.items[2].references[0], 'test/fixtures/source-property.js')
+        assert.equal(catalog.items[2].references[0], 'test/fixtures/source-property.js:6')
 
     it 'Extracts strings from calls to gettextCatalog', ->
         files = [
@@ -231,12 +231,12 @@ describe 'Extract', ->
         assert.equal(catalog.items[0].msgstr[0], '')
         assert.equal(catalog.items[0].msgstr[1], '')
         assert.equal(catalog.items[0].references.length, 1)
-        assert.equal(catalog.items[0].references[0], 'test/fixtures/catalog.js')
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/catalog.js:3')
         assert.equal(catalog.items.length, 2)
         assert.equal(catalog.items[1].msgid, 'Hello')
         assert.equal(catalog.items[1].msgstr, '')
         assert.equal(catalog.items[1].references.length, 1)
-        assert.equal(catalog.items[1].references[0], 'test/fixtures/catalog.js')
+        assert.equal(catalog.items[1].references[0], 'test/fixtures/catalog.js:2')
 
     it 'Extracts strings from deep path calls to obj.gettextCatalog', ->
         files = [
@@ -250,12 +250,12 @@ describe 'Extract', ->
         assert.equal(catalog.items[0].msgstr[0], '')
         assert.equal(catalog.items[0].msgstr[1], '')
         assert.equal(catalog.items[0].references.length, 1)
-        assert.equal(catalog.items[0].references[0], 'test/fixtures/deeppath_catalog.js')
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/deeppath_catalog.js:5')
         assert.equal(catalog.items.length, 2)
         assert.equal(catalog.items[1].msgid, 'Hello')
         assert.equal(catalog.items[1].msgstr, '')
         assert.equal(catalog.items[1].references.length, 1)
-        assert.equal(catalog.items[1].references[0], 'test/fixtures/deeppath_catalog.js')
+        assert.equal(catalog.items[1].references[0], 'test/fixtures/deeppath_catalog.js:4')
 
     it 'Extracts strings with quotes', ->
         files = [
@@ -390,12 +390,12 @@ describe 'Extract', ->
         assert.equal(catalog.items[0].msgid, 'Hello one concat!')
         assert.equal(catalog.items[0].msgstr, '')
         assert.equal(catalog.items[0].references.length, 1)
-        assert.equal(catalog.items[0].references[0], 'test/fixtures/concat.js')
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/concat.js:2')
 
         assert.equal(catalog.items[1].msgid, 'Hello two concat!')
         assert.equal(catalog.items[1].msgstr, '')
         assert.equal(catalog.items[1].references.length, 1)
-        assert.equal(catalog.items[1].references[0], 'test/fixtures/concat.js')
+        assert.equal(catalog.items[1].references[0], 'test/fixtures/concat.js:3')
 
     it 'Support data-translate for old-school HTML style', ->
         files = [
@@ -475,7 +475,7 @@ describe 'Extract', ->
         assert.equal(catalog.items[0].msgid, 'Hello custom')
         assert.equal(catalog.items[0].msgstr, '')
         assert.equal(catalog.items[0].references.length, 1)
-        assert.equal(catalog.items[0].references[0], 'test/fixtures/custom.js_extension')
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/custom.js_extension:2')
 
     it 'Extracts strings from non-delimited attribute', ->
         files = [
@@ -506,7 +506,7 @@ describe 'Extract', ->
         assert.equal(catalog.items[0].msgid, 'Hello custom')
         assert.equal(catalog.items[0].msgstr, '')
         assert.equal(catalog.items[0].references.length, 1)
-        assert.equal(catalog.items[0].references[0], 'test/fixtures/custom_marker_name.js')
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/custom_marker_name.js:4')
 
     it 'Can customize multiple marker name functions', ->
       files = [
@@ -519,17 +519,17 @@ describe 'Extract', ->
       assert.equal(catalog.items[0].msgid, 'Hello default')
       assert.equal(catalog.items[0].msgstr, '')
       assert.equal(catalog.items[0].references.length, 1)
-      assert.equal(catalog.items[0].references[0], 'test/fixtures/custom_marker_names.js')
+      assert.equal(catalog.items[0].references[0], 'test/fixtures/custom_marker_names.js:2')
 
       assert.equal(catalog.items[1].msgid, 'Hello first custom')
       assert.equal(catalog.items[1].msgstr, '')
       assert.equal(catalog.items[1].references.length, 1)
-      assert.equal(catalog.items[1].references[0], 'test/fixtures/custom_marker_names.js')
+      assert.equal(catalog.items[1].references[0], 'test/fixtures/custom_marker_names.js:6')
 
       assert.equal(catalog.items[2].msgid, 'Hello second custom')
       assert.equal(catalog.items[2].msgstr, '')
       assert.equal(catalog.items[2].references.length, 1)
-      assert.equal(catalog.items[2].references[0], 'test/fixtures/custom_marker_names.js')
+      assert.equal(catalog.items[2].references[0], 'test/fixtures/custom_marker_names.js:7')
 
     it 'Can post-process the catalog', ->
         called = false
@@ -579,3 +579,25 @@ describe 'Extract', ->
         extractor.parse(filename, fs.readFileSync(filename, 'utf8'))
         poText = extractor.toString()
         assert.equal(/\n"Project-Id-Version: \\n"\n/.test(poText), true)
+
+    it 'Extracts line numbers from JavaScript', ->
+        files = [
+            'test/fixtures/line_numbers.js'
+        ]
+        catalog = testExtract(files)
+
+        assert.equal(catalog.items[0].msgid, 'Line number 2')
+        assert.equal(catalog.items[0].msgstr, '')
+        assert.equal(catalog.items[0].references.length, 1)
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/line_numbers.js:2')
+
+    it "Doesn't extract line numbers from JavaScript if lineNumbers: false", ->
+        files = [
+            'test/fixtures/line_numbers.js'
+        ]
+        catalog = testExtract(files, { lineNumbers: false })
+
+        assert.equal(catalog.items[0].msgid, 'Line number 2')
+        assert.equal(catalog.items[0].msgstr, '')
+        assert.equal(catalog.items[0].references.length, 1)
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/line_numbers.js')

--- a/test/fixtures/line_numbers.js
+++ b/test/fixtures/line_numbers.js
@@ -1,0 +1,3 @@
+angular.module("myApp").controller("helloController", function (gettext, gettextCatalog) {
+    gettext('Line number 2');
+});


### PR DESCRIPTION
Esprima also supports column numbers, which would be pretty trivial to add to this code, but I've never seen that done in PO files. Let me know if that's something you'd want.

If you consider the generated POT file to be part of angular-gettext-tools's API, then this change requires a major version bump. Or you can turn off line numbers by default, but I think they're useful and should be on.
