### PR TITLE
Merge duplicate comments for same msgid

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -95,7 +95,7 @@ var Extractor = (function () {
             item.msgid_plural = plural;
             item.msgstr = ['', ''];
         }
-        if (extractedComment && extractedComment.length > 0) {
+        if (extractedComment && extractedComment.length > 0 && item.extractedComments.indexOf(extractedComment) === -1) {
             item.extractedComments.push(extractedComment);
         }
     };

--- a/test/extract.coffee
+++ b/test/extract.coffee
@@ -105,6 +105,19 @@ describe 'Extract', ->
         assert.equal(i[3].msgid, 'Two Part Comment')
         assert.equal(i[3].extractedComments, 'This is two part comment,Second part')
 
+    it 'Merges duplicate comments', ->
+      files = [
+          'test/fixtures/duplicate-comments.html'
+      ]
+      catalog = testExtract(files)
+
+      i = catalog.items
+      assert.equal(i.length, 1)
+
+      assert.equal(i[0].msgid, 'Translate this')
+      assert.equal(i[0].extractedComments.length, 1)
+      assert.equal(i[0].extractedComments, 'This is a comment')
+
     it 'Merges singular and plural strings', ->
         files = [
             'test/fixtures/merge.html'

--- a/test/fixtures/duplicate-comments.html
+++ b/test/fixtures/duplicate-comments.html
@@ -1,0 +1,2 @@
+<p translate-comment="This is a comment" translate>Translate this</p>
+<p translate-comment="This is a comment" translate>Translate this</p>


### PR DESCRIPTION
Extracted comments can get duplicated if you have the same msgid with the same comment:

``` po
#. Translators: {{user.name}} is a variable
#. Translators: {{user.name}} is a variable
#: ../bar.html
#: ../baz.html
msgid "Hello {{user.name}}!"
msgstr ""
```

This PR makes sure we only add a comment once:

``` po
#. Translators: {{user.name}} is a variable
#: ../bar.html
#: ../baz.html
msgid "Hello {{user.name}}!"
msgstr ""
```
