### PR TITLE
Data attributes

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -196,23 +196,20 @@ var Extractor = (function () {
             var extractedComment;
             node = $(n);
 
+            var getAttr = function (attr) {
+                return node.attr(attr) || node.data(attr);
+            };
+
             for (var attr in node.attr()) {
-                if (attr === 'translate') {
+                if (attr === 'translate' || attr === 'data-translate') {
                     str = node.html();
-                    plural = node.attr('translate-plural');
-                    extractedComment = node.attr('translate-comment');
+                    plural = getAttr('translate-plural');
+                    extractedComment = getAttr('translate-comment');
                     self.addString(filename, str, plural, extractedComment);
                 } else if (matches = noDelimRegex.exec(node.attr(attr))) {
                     str = matches[2].replace(/\\\'/g, '\'');
                     self.addString(filename, str);
                 }
-            }
-
-            if (typeof node.attr('data-translate') !== 'undefined') {
-                str = node.html();
-                plural = node.attr('data-translate-plural');
-                extractedComment = node.attr('data-translate-comment');
-                self.addString(filename, str, plural, extractedComment);
             }
         });
 

--- a/test/extract.coffee
+++ b/test/extract.coffee
@@ -403,7 +403,7 @@ describe 'Extract', ->
         ]
         catalog = testExtract(files)
 
-        assert.equal(catalog.items.length, 2)
+        assert.equal(catalog.items.length, 6)
 
         assert.equal(catalog.items[0].msgid, '1: Hello!')
         assert.equal(catalog.items[0].msgstr, '')
@@ -416,6 +416,36 @@ describe 'Extract', ->
         assert.equal(catalog.items[1].references[0], 'test/fixtures/data.html')
         assert.equal(catalog.items[1].extractedComments.length, 1)
         assert.equal(catalog.items[1].extractedComments[0], 'comment')
+
+        assert.equal(catalog.items[2].msgid, '3: with data-comment')
+        assert.equal(catalog.items[2].msgstr, '')
+        assert.equal(catalog.items[2].references.length, 1)
+        assert.equal(catalog.items[2].references[0], 'test/fixtures/data.html')
+        assert.equal(catalog.items[2].extractedComments.length, 1)
+        assert.equal(catalog.items[2].extractedComments[0], 'comment')
+
+        assert.equal(catalog.items[3].msgid, '4: translate with data-comment')
+        assert.equal(catalog.items[3].msgstr, '')
+        assert.equal(catalog.items[3].references.length, 1)
+        assert.equal(catalog.items[3].references[0], 'test/fixtures/data.html')
+        assert.equal(catalog.items[3].extractedComments.length, 1)
+        assert.equal(catalog.items[3].extractedComments[0], 'comment')
+
+        assert.equal(catalog.items[4].msgid, '5: translate with data-plural')
+        assert.equal(catalog.items[4].msgstr.length, 2)
+        assert.equal(catalog.items[4].msgstr[0], '')
+        assert.equal(catalog.items[4].msgstr[1], '')
+        assert.equal(catalog.items[4].references.length, 1)
+        assert.equal(catalog.items[4].references[0], 'test/fixtures/data.html')
+        assert.equal(catalog.items[4].msgid_plural, 'foos')
+
+        assert.equal(catalog.items[5].msgid, '6: data-translate with data-plural')
+        assert.equal(catalog.items[5].msgstr.length, 2)
+        assert.equal(catalog.items[5].msgstr[0], '')
+        assert.equal(catalog.items[5].msgstr[1], '')
+        assert.equal(catalog.items[5].references.length, 1)
+        assert.equal(catalog.items[5].references[0], 'test/fixtures/data.html')
+        assert.equal(catalog.items[5].msgid_plural, 'foos')
 
     it 'Extract strings from custom HTML file extensions', ->
         files = [

--- a/test/fixtures/data.html
+++ b/test/fixtures/data.html
@@ -1,6 +1,14 @@
 <html>
     <body>
         <h1 data-translate>1: Hello!</h1>
-        <h1 data-translate data-translate-comment="comment">2: with comment</h1>
+        <h1 data-translate translate-comment="comment">2: with comment</h1>
+        <h1 data-translate data-translate-comment="comment">3: with data-comment</h1>
+        <h1 translate data-translate-comment="comment">4: translate with data-comment</h1>
+        <h1 translate translate-n="count" data-translate-plural="foos">
+          5: translate with data-plural
+        </h1>
+        <h1 translate translate-n="count" data-translate-plural="foos">
+          6: data-translate with data-plural
+        </h1>
     </body>
 </html>


### PR DESCRIPTION
Previously, `data-translate-plural` and `data-translate-comment` could only be used on `data-translate` (if they worked at all). This PR allows them to be used on regular `translate` attributes as well.
