### PR TITLE
`<translate>`

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -183,28 +183,27 @@ var Extractor = (function () {
         var self = this;
 
         $('*').each(function (index, n) {
-            var node;
+            var node = $(n);
+            var getAttr = function (attr) {
+                return node.attr(attr) || node.data(attr);
+            };
+            var str = node.html();
+            var plural = getAttr('translate-plural');
+            var extractedComment = getAttr('translate-comment');
 
             if (n.name === 'script' && n.attribs.type ==='text/ng-template') {
-                node = $(n);
                 self.extractHtml(filename, node.text());
                 return;
             }
 
-            var str;
-            var plural;
-            var extractedComment;
-            node = $(n);
-
-            var getAttr = function (attr) {
-                return node.attr(attr) || node.data(attr);
-            };
+            if (node.is('translate')) {
+                self.addString(filename, str, plural, extractedComment);
+                return;
+            }
 
             for (var attr in node.attr()) {
                 if (attr === 'translate' || attr === 'data-translate') {
-                    str = node.html();
-                    plural = getAttr('translate-plural');
-                    extractedComment = getAttr('translate-comment');
+                    str = node.html(); // this shouldn't be necessary, but it is
                     self.addString(filename, str, plural, extractedComment);
                 } else if (matches = noDelimRegex.exec(node.attr(attr))) {
                     str = matches[2].replace(/\\\'/g, '\'');

--- a/test/extract.coffee
+++ b/test/extract.coffee
@@ -494,6 +494,30 @@ describe 'Extract', ->
         assert.equal(catalog.items[1].references.length, 1)
         assert.equal(catalog.items[1].references[0], 'test/fixtures/no_delimiter.html')
 
+    it 'Extracts strings from <translate> element', ->
+        files = [
+            'test/fixtures/translate-element.html'
+        ]
+        catalog = testExtract(files)
+
+        assert.equal(catalog.items.length, 2)
+
+        assert.equal(catalog.items[0].msgid, '1: message')
+        assert.equal(catalog.items[0].msgstr, '')
+        assert.equal(catalog.items[0].references.length, 1)
+        assert.equal(catalog.items[0].references[0], 'test/fixtures/translate-element.html')
+        assert.equal(catalog.items[0].extractedComments.length, 0)
+
+        assert.equal(catalog.items[1].msgid, '2: message with comment and plural')
+        assert.equal(catalog.items[1].msgid_plural, 'foos')
+        assert.equal(catalog.items[1].msgstr.length, 2)
+        assert.equal(catalog.items[1].msgstr[0], '')
+        assert.equal(catalog.items[1].msgstr[1], '')
+        assert.equal(catalog.items[1].references.length, 1)
+        assert.equal(catalog.items[1].references[0], 'test/fixtures/translate-element.html')
+        assert.equal(catalog.items[1].extractedComments.length, 1)
+        assert.equal(catalog.items[1].extractedComments[0], 'comment')
+
     it 'Can customize the marker name', ->
         files = [
             'test/fixtures/custom_marker_name.js'

--- a/test/fixtures/translate-element.html
+++ b/test/fixtures/translate-element.html
@@ -1,0 +1,4 @@
+<translate>1: message</translate>
+<translate translate-comment="comment" translate-n="count" translate-plural="foos">
+    2: message with comment and plural
+</translate>


### PR DESCRIPTION
Support extraction from `<translate>` element. Closes #6.
