### PR TITLE
Auto create translation's module

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -7,15 +7,21 @@ var formats = {
             return '    gettextCatalog.setStrings(\'' + locale + '\', ' + JSON.stringify(strings) + ');\n';
         },
         format: function (locales, options) {
-            var module = 'angular.module(\'' + options.module + '\')' +
-                            '.run([\'gettextCatalog\', function (gettextCatalog) {\n' +
-                                '/* jshint -W100 */\n' +
-                                locales.join('') +
-                                '/* jshint +W100 */\n';
+            var module = '(function(module) {' +
+                         'try {' +
+                            'module = angular.module(\'' + options.module + '\');' +
+                         '} catch (e) {' +
+                            'module = angular.module(\'' + options.module + '\', []);' +
+                         '}';
+            module +=    'module.run([\'gettextCatalog\', function (gettextCatalog) {\n' +
+                            '/* jshint -W100 */\n' +
+                            locales.join('') +
+                            '/* jshint +W100 */\n';
             if (options.defaultLanguage) {
                 module += 'gettextCatalog.currentLanguage = \'' + options.defaultLanguage + '\';\n';
             }
             module += '}]);';
+            module += '})();';
 
             if (options.requirejs) {
                 return 'define([\'angular\', \'' + options.modulePath + '\'], function (angular) {\n' + module + '\n});';


### PR DESCRIPTION
In order to be fully isolated, we better create the translations module near its initialization.
So we check if the module exists by trying to get a handle for it. If we fail - we create the module and then use it.