### PR TITLE
Allow mixed quotes if it avoids escaping

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -27,7 +27,7 @@
     "disallowSpaceBeforePostfixUnaryOperators": ["++", "--"],
     "requireSpaceBeforeBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
     "requireSpaceAfterBinaryOperators": ["+", "-", "/", "*", "=", "==", "===", "!=", "!=="],
-    "validateQuoteMarks": true,
+    "validateQuoteMarks": { "mark": true, "escape": true },
     "validateIndentation": 4,
     "disallowTrailingWhitespace": true,
     "disallowKeywordsOnNewLine": ["else"],


### PR DESCRIPTION
For example, this is now OK:

``` js
var foo = "bar";
foo = '"bar"'; // OK to use ' because string contains "
```

whereas before you had to pick a single quotemark to use per file and escape uses of the other quotemark in string literals.
