### PR TITLE
Surround esprima parsing with try/catch

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,6 +12,7 @@
   "node": true,
   "strict": true,
   "white": true,
+  "indent": 4,
   "predef": [
     "$",
     "angular",

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -152,11 +152,16 @@ var Extractor = (function () {
 
     Extractor.prototype.extractJs = function (filename, src) {
         var self = this;
-        var syntax = esprima.parse(src, {
-            tolerant: true,
-            attachComment: true,
-            loc: true
-        });
+        var syntax;
+        try {
+            syntax = esprima.parse(src, {
+                tolerant: true,
+                attachComment: true,
+                loc: true
+            });
+        } catch (err) {
+            return;
+        }
 
         function isGettext(node) {
             return node !== null &&

--- a/test/extract_javascript.js
+++ b/test/extract_javascript.js
@@ -71,4 +71,11 @@ describe('Extracting from Javascript', function () {
         assert.equal(catalog.items[1].msgstr, '');
         assert.deepEqual(catalog.items[1].references, ['test/fixtures/deeppath_catalog.js:4']);
     });
+
+    it('supports invalid javascript syntax without exception', function () {
+        var files = [
+            'test/fixtures/deeppath_catalog_invalid.js'
+        ];
+        testExtract(files);
+    });
 });

--- a/test/fixtures/deeppath_catalog_invalid.js
+++ b/test/fixtures/deeppath_catalog_invalid.js
@@ -1,0 +1,6 @@
+angular.module("myApp").controller("helloController", function (gettextCatalog) {
+    var obj = {[
+        gettextCatalog: gettextCatalog };
+    var myString = obj.gettextCatalog.getString("Hello");
+    var myString2 = obj.gettextCatalog.getPlural(3, "Bird", "Birds");
+});


### PR DESCRIPTION
I have an issue using `gulp-angular-gettext` when trying to extract strings from ES6 javascript files.

Files causing problems was using ES6 `import from` statement which is not supported at the moment by esprima.

I think it's more safe to surround `esprima.parse()` by a `try/catch`, and just skip if it fails to parse the file. Using `tolerant: true` may not be suffisant.

This allow gulp to keep processing other files and continue it's pipeline if a javascript file fails.