### PR TITLE
fix:    update jshint exception switch to current jshint version

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -11,9 +11,9 @@ var formats = {
         format: function (locales, options) {
             var module = 'angular.module(\'' + options.module + '\')' +
                             '.run([\'gettextCatalog\', function (gettextCatalog) {\n' +
-                                '/* jshint -W100 */\n' +
+                                '/* jshint -W110 */\n' +
                                 locales.join('') +
-                                '/* jshint +W100 */\n';
+                                '/* jshint +W110 */\n';
             if (options.defaultLanguage) {
                 module += 'gettextCatalog.currentLanguage = \'' + options.defaultLanguage + '\';\n';
             }


### PR DESCRIPTION
update the jshint exception switch to current (2.6.0) version for
mixed quotation marks. As of jshint > 1.0 this exception is W110 instead
of the used W100