### PR TITLE
Extract context from gettextCatalog.getString()

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -217,7 +217,9 @@ var Extractor = (function () {
 
             if (isGettext(node) || isGetString(node)) {
                 str = getJSExpression(node.arguments[0]);
-                context = getJSExpression(node.arguments[2] || '');
+                if (node.arguments[2]) {
+                    context = getJSExpression(node.arguments[2]);
+                }
             } else if (isGetPlural(node)) {
                 singular = getJSExpression(node.arguments[1]);
                 plural = getJSExpression(node.arguments[2]);

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -209,6 +209,7 @@ var Extractor = (function () {
 
         walkJs(syntax, function (node, parentComment) {
             var str;
+            var context;
             var singular;
             var plural;
             var extractedComments = [];
@@ -216,6 +217,7 @@ var Extractor = (function () {
 
             if (isGettext(node) || isGetString(node)) {
                 str = getJSExpression(node.arguments[0]);
+                context = getJSExpression(node.arguments[2] || '');
             } else if (isGetPlural(node)) {
                 singular = getJSExpression(node.arguments[1]);
                 plural = getJSExpression(node.arguments[2]);
@@ -228,7 +230,7 @@ var Extractor = (function () {
                     }
                 });
                 if (str) {
-                    self.addString(reference, str, plural, comments2String(extractedComments));
+                    self.addString(reference, str, plural, comments2String(extractedComments), context);
                 } else if (singular) {
                     self.addString(reference, singular, plural, comments2String(extractedComments));
                 }

--- a/test/extract_javascript.js
+++ b/test/extract_javascript.js
@@ -42,16 +42,22 @@ describe('Extracting from Javascript', function () {
         ];
         var catalog = testExtract(files);
 
+        assert.equal(catalog.items.length, 3);
         assert.equal(catalog.items[0].msgid, 'Bird');
         assert.equal(catalog.items[0].msgid_plural, 'Birds');
         assert.equal(catalog.items[0].msgstr.length, 2);
         assert.equal(catalog.items[0].msgstr[0], '');
         assert.equal(catalog.items[0].msgstr[1], '');
-        assert.deepEqual(catalog.items[0].references, ['test/fixtures/catalog.js:3']);
-        assert.equal(catalog.items.length, 2);
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/catalog.js:4']);
+
         assert.equal(catalog.items[1].msgid, 'Hello');
         assert.equal(catalog.items[1].msgstr, '');
         assert.deepEqual(catalog.items[1].references, ['test/fixtures/catalog.js:2']);
+
+        assert.equal(catalog.items[2].msgid, 'Hello2');
+        assert.equal(catalog.items[2].msgstr, '');
+        assert.equal(catalog.items[2].msgctxt, 'Context');
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/catalog.js:3']);
     });
 
     it('supports foo.gettextCatalog.getString()', function () {

--- a/test/fixtures/catalog.js
+++ b/test/fixtures/catalog.js
@@ -1,5 +1,5 @@
 angular.module("myApp").controller("helloController", function (gettextCatalog) {
     var myString = gettextCatalog.getString("Hello");
-	var myString2 = gettextCatalog.getString("Hello2", null, "Context");
+    var myString2 = gettextCatalog.getString("Hello2", null, "Context");
     var myString3 = gettextCatalog.getPlural(3, "Bird", "Birds");
 });

--- a/test/fixtures/catalog.js
+++ b/test/fixtures/catalog.js
@@ -1,4 +1,5 @@
 angular.module("myApp").controller("helloController", function (gettextCatalog) {
     var myString = gettextCatalog.getString("Hello");
-    var myString2 = gettextCatalog.getPlural(3, "Bird", "Birds");
+	var myString2 = gettextCatalog.getString("Hello2", null, "Context");
+    var myString3 = gettextCatalog.getPlural(3, "Bird", "Birds");
 });


### PR DESCRIPTION
Added support for extracting context (msgctxt) from getString() in JS as discussed in issue rubenv/angular-gettext-website#4.

Seems to work nicely, but I'm a bit uncertain if I should do something else when context is undefined. Doesn't seem to be any checks like that for other parameters (for example try making a test for getPlural() not giving it 3 parameters).