### PR TITLE
Option for custom id transforms.

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -64,6 +64,7 @@ var Extractor = (function () {
         this.options = _.extend({
             startDelim: '{{',
             endDelim: '}}',
+            idTransform: function (s) { return s.trim(); },
             markerName: 'gettext',
             markerNames: [],
             lineNumbers: true,
@@ -97,7 +98,7 @@ var Extractor = (function () {
             reference = { file: reference };
         }
 
-        string = string.trim();
+        string = this.options.idTransform(string);
 
         if (string.length === 0) {
             return;

--- a/test/extract.js
+++ b/test/extract.js
@@ -109,6 +109,20 @@ describe('Extract', function () {
         assert.deepEqual(catalog.items[0].references, ['test/fixtures/ngif.html:3']);
     });
 
+    it('Can customize trimming whitespace around strings', function () {
+        var files = [
+            'test/fixtures/strip-custom.html'
+        ];
+        var catalog = testExtract(files, {
+            idTransform: function (s) { return s.replace(/\s+/g,' '); }
+        });
+
+        assert.equal(catalog.items.length, 1);
+        assert.equal(catalog.items[0].msgid, ' Hello strip custom ');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/strip-custom.html:3']);
+    });
+
     it('Can customize delimiters', function () {
         var files = [
             'test/fixtures/delim.html'

--- a/test/fixtures/strip-custom.html
+++ b/test/fixtures/strip-custom.html
@@ -1,0 +1,8 @@
+<html>
+    <body>
+        <p translate> Hello
+          strip   custom
+        </p>
+    </body>
+</html>
+


### PR DESCRIPTION
A custom id mapping can be provided. Examples:
// do not trim the whitespace from the string ends (the current default)
 'idTransform': fn(s) { return s; }
// apply html whitespace trimming rules
 'idTransform': fn(s) { return s.replace(/\s+/g,' '); }

I am also submitting a matching pull request for rubenv/angular-gettext
References rubenv/grunt-angular-gettext#1, rubenv/angular-gettext#183