### PR TITLE
added support for line JS

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -297,6 +297,12 @@ var Extractor = (function () {
                     extractHtml(node.text(), newlines(n.startIndex).length);
                     return;
                 }
+                if(n.name === 'script' && n.attribs.type === 'text/javascript'){
+                    if(!n.attribs.src){
+                        //inline JavaScript
+                        return self.extractJs(filename, node.text());    
+                    }
+                }
 
                 if (node.is('translate')) {
                     self.addString(reference(n.startIndex), str, plural, extractedComment);


### PR DESCRIPTION
support for JS-block inside HTML files added

```html
<html>
<!-- .. -->
<span translate>foo</span>
<script type="text/javascript">
angular.module("myMod").run(function(gettext){
   gettext("foo"); // <-- now recognized
});
</script>
<!-- .. -->
</html>
```