### PR TITLE
Extract JS <script> tags from HTML

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -150,7 +150,10 @@ var Extractor = (function () {
         }
     };
 
-    Extractor.prototype.extractJs = function (filename, src) {
+    Extractor.prototype.extractJs = function (filename, src, lineNumber) {
+        // used for line number of JS in HTML <script> tags
+        lineNumber = lineNumber || 0;
+
         var self = this;
         var syntax;
         try {
@@ -237,7 +240,20 @@ var Extractor = (function () {
             var singular;
             var plural;
             var extractedComments = [];
-            var reference = { file: filename, location: node ? node.loc : null };
+            var reference = {
+                file: filename,
+                location: (function () {
+                    if (!node || !node.loc || !node.loc.start) {
+                        return null;
+                    }
+
+                    return {
+                        start: {
+                            line: node.loc.start.line + lineNumber
+                        }
+                    };
+                })()
+            };
 
             if (isGettext(node) || isGetString(node)) {
                 str = getJSExpression(node.arguments[0]);
@@ -293,9 +309,18 @@ var Extractor = (function () {
                 var extractedComment = getAttr('translate-comment');
                 var context = getAttr('translate-context');
 
-                if (n.name === 'script' && n.attribs.type === 'text/ng-template') {
-                    extractHtml(node.text(), newlines(n.startIndex).length);
-                    return;
+                if (n.name === 'script') {
+                    if (n.attribs.type === 'text/ng-template') {
+                        extractHtml(node.text(), newlines(n.startIndex).length);
+                        return;
+                    }
+
+                    // In HTML5, type defaults to text/javascript.
+                    // In HTML4, it's required, so if it's not there, just assume it's JS
+                    if (!n.attribs.type || n.attribs.type === 'text/javascript') {
+                        self.extractJs(filename, node.text(), newlines(n.startIndex).length);
+                        return;
+                    }
                 }
 
                 if (node.is('translate')) {

--- a/test/extract_javascript.js
+++ b/test/extract_javascript.js
@@ -84,4 +84,39 @@ describe('Extracting from Javascript', function () {
         ];
         testExtract(files);
     });
+
+    describe('from HTML <script> tags', function () {
+        it('should work if <script> has no type', function () {
+            // In HTML5, type defaults to text/javascript.
+            // In HTML4, it's required, so if it's not there, just assume it's JS
+            var files = [
+                'test/fixtures/js-in-script-tags/no-type.html'
+            ];
+            var catalog = testExtract(files);
+
+            assert.equal(catalog.items.length, 1);
+            assert.equal(catalog.items[0].msgid, 'Hi');
+            assert.deepEqual(catalog.items[0].references, ['test/fixtures/js-in-script-tags/no-type.html:4']);
+        });
+
+        it('should work if <script> is type="text/javascript"', function () {
+            var files = [
+                'test/fixtures/js-in-script-tags/type-javascript.html'
+            ];
+            var catalog = testExtract(files);
+
+            assert.equal(catalog.items.length, 1);
+            assert.equal(catalog.items[0].msgid, 'Hi');
+            assert.deepEqual(catalog.items[0].references, ['test/fixtures/js-in-script-tags/type-javascript.html:4']);
+        });
+
+        it('should not extract <script> if type is not javascript', function () {
+            var files = [
+                'test/fixtures/js-in-script-tags/not-javascript.html'
+            ];
+            var catalog = testExtract(files);
+
+            assert.equal(catalog.items.length, 0);
+        });
+    });
 });

--- a/test/fixtures/js-in-script-tags/no-type.html
+++ b/test/fixtures/js-in-script-tags/no-type.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+    <script>
+    gettext("Hi");
+    </script>
+</body>
+</html>

--- a/test/fixtures/js-in-script-tags/not-javascript.html
+++ b/test/fixtures/js-in-script-tags/not-javascript.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+    <script type="text/not-javascript">
+    gettext("Hi");
+    </script>
+</body>
+</html>

--- a/test/fixtures/js-in-script-tags/type-javascript.html
+++ b/test/fixtures/js-in-script-tags/type-javascript.html
@@ -1,0 +1,7 @@
+<html>
+<body>
+    <script type="text/javascript">
+    gettext("Hi");
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Cleaned up version of @thewilli's PR. Differences:
* Fixed lint errors
* Added tests
* Correctly handled line numbers
* Don't bother checking if `src` attribute is set. We don't do that for script tags containing templates and some browsers do allow you to have `src` and content in HTML4.