### PR TITLE
Add support for browserify

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -9,7 +9,7 @@ var formats = {
             return '    gettextCatalog.setStrings(\'' + locale + '\', ' + JSON.stringify(strings) + ');\n';
         },
         format: function (locales, options) {
-            var module = 'angular.module(\'' + options.module + '\')' +
+            var module = options.angular + '.module(\'' + options.module + '\')' +
                             '.run([\'gettextCatalog\', function (gettextCatalog) {\n' +
                                 '/* jshint -W100 */\n' +
                                 locales.join('') +
@@ -52,7 +52,8 @@ var Compiler = (function () {
     function Compiler(options) {
         this.options = _.extend({
             format: 'javascript',
-            module: 'gettext'
+            module: 'gettext',
+            angular: 'angular'
         }, options);
     }
 


### PR DESCRIPTION
Browserify needs to require Angular's global before using it. Add an
option to pass in the expression to do that.

The usage in the `Gruntfile.js` might look like this:

```
nggettext_compile: {
  all: {
    files: {
      'app/scripts/translations.js': ['po/*.po']
    },
    options: {
      angular: 'require(\'angular\')'
    }
  }
},
```
