### PR TITLE
fail-safe msgstr verification

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -75,7 +75,7 @@ var Compiler = (function () {
             for (var i = 0; i < catalog.items.length; i++) {
                 var item = catalog.items[i];
                 var ctx = item.msgctxt || noContext;
-                if (item.msgstr[0].length > 0 && !item.flags.fuzzy && !item.obsolete) {
+                if (item.msgstr.length > 0 && item.msgstr[0].length > 0 && !item.flags.fuzzy && !item.obsolete) {
                     if (!strings[item.msgid]) {
                         strings[item.msgid] = {};
                     }


### PR DESCRIPTION
for some unknown reason 'po.parse' is sometimes returning items as empty strings.
a safer verification is needed for these cases.