### PR TITLE
fixed hectic missing strings

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -348,6 +348,7 @@ var Extractor = (function () {
                     } else if (matches = noDelimRegex.exec(node.attr(attr))) {
                         str = matches[2].replace(/\\\'/g, '\'');
                         self.addString(reference(n.startIndex), str);
+                        noDelimRegex.lastIndex = 0;
                     }
                 }
             });

--- a/test/extract_filters.js
+++ b/test/extract_filters.js
@@ -57,4 +57,29 @@ describe('Extracting filters', function () {
         assert.equal(catalog.items[1].references.length, 1);
         assert.deepEqual(catalog.items[1].references, ['test/fixtures/escaped_quotes.html:4']);
     });
+
+    it('works on filter strings in multiple expression attributes', function () {
+        var files = [
+            'test/fixtures/filter-in-multiple-expression-attributes.html'
+        ];
+        var catalog = testExtract(files);
+
+        assert.equal(catalog.items.length, 4);
+
+        assert.equal(catalog.items[0].msgid, 'expr1');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/filter-in-multiple-expression-attributes.html:3']);
+
+        assert.equal(catalog.items[1].msgid, 'expr2');
+        assert.equal(catalog.items[1].msgstr, '');
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/filter-in-multiple-expression-attributes.html:3']);
+
+        assert.equal(catalog.items[2].msgid, 'expr3');
+        assert.equal(catalog.items[2].msgstr, '');
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/filter-in-multiple-expression-attributes.html:3']);
+
+        assert.equal(catalog.items[3].msgid, 'expr4');
+        assert.equal(catalog.items[3].msgstr, '');
+        assert.deepEqual(catalog.items[3].references, ['test/fixtures/filter-in-multiple-expression-attributes.html:3']);
+    });
 });

--- a/test/fixtures/filter-in-multiple-expression-attributes.html
+++ b/test/fixtures/filter-in-multiple-expression-attributes.html
@@ -1,0 +1,5 @@
+<html>
+    <body>
+        <my-directive expr1="'expr1' | translate" expr2="'expr2' | translate" expr3="'expr3' | translate" expr4="'expr4' | translate"></my-directive>
+    </body>
+</html>


### PR DESCRIPTION
http://stackoverflow.com/a/11477448/1108919

>A JavaScript ``RegExp`` object is stateful.
>
>When the regex is global, if you call a method the same regex object, it will start from the index past the end of the last match.
>
>When no more matches are found, the index is reset to ``0`` automatically.
>
>To reset it manually, set the ``lastIndex`` property.