### PR TITLE
Convert horizontal ellipsis in msgids

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -73,15 +73,17 @@ var Compiler = (function () {
 
             var strings = {};
             for (var i = 0; i < catalog.items.length; i++) {
-                var item = catalog.items[i];
-                var ctx = item.msgctxt || noContext;
+                var item  = catalog.items[i];
+                var msgid = item.msgid.replace(/&hellip;?/g, '…');
+                var ctx   = item.msgctxt || noContext;
+
                 if (item.msgstr[0].length > 0 && !item.flags.fuzzy && !item.obsolete) {
-                    if (!strings[item.msgid]) {
-                        strings[item.msgid] = {};
+                    if (!strings[msgid]) {
+                        strings[msgid] = {};
                     }
 
                     // Add array for plural, single string for signular.
-                    strings[item.msgid][ctx] = item.msgstr.length === 1 ? item.msgstr[0] : item.msgstr;
+                    strings[msgid][ctx] = item.msgstr.length === 1 ? item.msgstr[0] : item.msgstr;
                 }
             }
 

--- a/test/compile.js
+++ b/test/compile.js
@@ -253,4 +253,15 @@ describe('Compile', function () {
             'Non-breaking&nbsp;space': 'Harde&nbsp;spatie'
         });
     });
+
+    it('Converts horizontal ellipsis in msgids', function () {
+        var files = ['test/fixtures/hellip.po'];
+        var output = testCompile(files, {
+            format: 'json'
+        });
+        var data = JSON.parse(output);
+        assert.deepEqual(data.nl, {
+            'Dots…': 'Puntjes&hellip;'
+        });
+    });
 });

--- a/test/compile.js
+++ b/test/compile.js
@@ -242,4 +242,15 @@ describe('Compile', function () {
         vm.runInContext(output, context);
         assert(catalog.called);
     });
+
+    it('Leaves non-breaking spaces in msgids in tact', function () {
+        var files = ['test/fixtures/nbsp.po'];
+        var output = testCompile(files, {
+            format: 'json'
+        });
+        var data = JSON.parse(output);
+        assert.deepEqual(data.nl, {
+            'Non-breaking&nbsp;space': 'Harde&nbsp;spatie'
+        });
+    });
 });

--- a/test/fixtures/hellip.po
+++ b/test/fixtures/hellip.po
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"X-Generator: Poedit 1.5.7\n"
+
+#: test/fixtures/hellip.html
+msgid "Dots&hellip;"
+msgstr "Puntjes&hellip;"

--- a/test/fixtures/nbsp.po
+++ b/test/fixtures/nbsp.po
@@ -1,0 +1,17 @@
+msgid ""
+msgstr ""
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"X-Generator: Poedit 1.5.7\n"
+
+#: test/fixtures/nbsp.html
+msgid "Non-breaking&nbsp;space"
+msgstr "Harde&nbsp;spatie"


### PR DESCRIPTION
**tl;dr:** angular-gettext-extract extracts `&hellip;` as a html-entity into .po-files, but browsers automatically convert `&hellip;` to `…`.

This means that your translations-file may have a msgid `"dots&hellip;"`, but the translate-directive will read `"dots…"` from a html-element and try to find that as a msgid (and find nothing).

To get around this we convert any &hellip; to … when compiling from a .po-file.

---

# The situation

Consider the following:

**page.html:**
```html
<p translate>Dots&hellip;</p>
```

**translations.po:**
```po
msgid "Dots&hellip;"
msgstr "Puntjes&hellip;"
```

Browsers automatically render `&hellip;` though.

**DOM:**
```html
<p translate>Dots…</p>
```

**Console:**
```javascript
p.innerHTML // -> "Dots…"
```

# The problem

So browsers automatically convert `&hellip;` to `…` (1 character). When the translate-directive tries to find the msgid `"Dots…"`, it will find nothing, because the translation is listed under `"Dots&hellip;"`.

There is no deterministic way to backtrack `…` to `&hellip;` in the DOM; a html-file may read `&hellip;` or `…` – in both cases the text-value in the DOM will read `…` (1 character)

In your .po-file, you will want the original text from the html-file though, so that you can translate *“Dots&hellip;”* to *“Puntjes&hellip;”*, instead of having to translate from *“Dots…”* (you’ll want to use the html-entity in your translated string).

# The solution

Bearing this in mind, it makes sense to convert all occurrences of `&hellip;` to `…` during compile. This means that msgids will still contain `&hellip;`, but the compiled translations-file will only contain `…` in msgids.

So in your .po-file you won’t notice anything, but when the translate-directive looks for `Dots…`, it wil actually find it.