### PR TITLE
C# support for translation

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -43,6 +43,50 @@ var formats = {
             });
             return JSON.stringify(result);
         }
+    },
+    csharp: {
+        addLocale: function (locale, strings) {
+            var result = 'var dictionary' + locale + ' = new Dictionary<string, string>();\n';
+            for (var key in strings) {
+                result += 'dictionary' + locale + '.Add("' + key + '","' + strings[key] + '");\n';
+            }
+            result += '_translations.Add("' + locale + '", dictionary' + locale + ');\n';
+
+            return result;
+        },
+        format: function (locales, options) {
+            var module = 'using System.Collections.Generic;\n' +
+                'namespace ' + options.namespace + '\n' +
+                '{\n' +
+                'public static class Translations' +
+                '{\n' +
+                'public  static readonly Dictionary<string, Dictionary<string, string>> _translations = new Dictionary<string, Dictionary<string, string>>();\n' +
+                'private static Dictionary<string, string> _currentLanguage;\n' +
+                'static Translations()\n' +
+                '{\n' +
+                locales.join('');
+
+            if (options.defaultLanguage) {
+                module += 'SetCurrentLanguage("' + options.defaultLanguage + '");\n';
+            }
+            module += '}\n' +
+                'public static void SetCurrentLanguage(string languageCode)\n' +
+                '{\n' +
+                'foreach (var translation in _translations)\n' +
+                '{\n' +
+                'if (translation.Key != languageCode) continue;\n' +
+                '_currentLanguage = translation.Value;\n' +
+                'return;\n' +
+                '}\n' +
+                '}\n' +
+                'public static string Translate(string key)\n' +
+                '{\n' +
+                'return _currentLanguage != null ? _currentLanguage[key] : key;\n' +
+                '}\n' +
+                '}\n' +
+                '}\n';
+            return module;
+        }
     }
 };
 
@@ -52,7 +96,8 @@ var Compiler = (function () {
     function Compiler(options) {
         this.options = _.extend({
             format: 'javascript',
-            module: 'gettext'
+            module: 'gettext',
+            namespace: 'Core.Common'
         }, options);
     }
 
@@ -60,8 +105,21 @@ var Compiler = (function () {
         return formats.hasOwnProperty(format);
     };
 
-    Compiler.prototype.convertPo = function (inputs) {
-        var format = formats[this.options.format];
+    Compiler.prototype.convertPo = function (inputs, filename) {
+
+        var format;
+
+        if (filename) {
+            var extension = filename.split('.').pop();
+            if (extension === 'cs') {
+                format = formats['csharp'];
+            } else {
+                format = formats[this.options.format];
+            }
+        } else {
+            format = formats[this.options.format];
+        }
+
         var locales = [];
 
         inputs.forEach(function (input) {

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -79,9 +79,10 @@ var Extractor = (function () {
                 erb: 'html',
                 js: 'js',
                 tag: 'html',
-                jsp: 'html'
+                jsp: 'html',
+                cs: 'c#'
             },
-            postProcess: function (po) {}
+            postProcess: function (po) { }
         }, options);
         this.options.markerNames.unshift(this.options.markerName);
         this.options.attributes.unshift(this.options.attribute);
@@ -285,6 +286,30 @@ var Extractor = (function () {
         });
     };
 
+
+    Extractor.prototype.extractCs = function (filename, src) {
+        var self = this;
+        var newlines = function (index) {
+            return src.substr(0, index).match(/\n/g) || [];
+        };
+
+        var reference = function (index) {
+            return {
+                file: filename,
+                location: {
+                    start: {
+                        line: newlines(index).length + 1
+                    }
+                }
+            };
+        };
+        var pattern = /_translate_\s*=\s*"(.*?)"/g;
+        var match;
+        while ((match = pattern.exec(src))) {
+            self.addString(reference(match.index), match[1]);
+        }
+    };
+
     Extractor.prototype.extractHtml = function (filename, src) {
         var extractHtml = function (src, lineNumber) {
             var $ = cheerio.load(src, { decodeEntities: false, withStartIndices: true });
@@ -365,6 +390,9 @@ var Extractor = (function () {
         extractHtml(src, 0);
     };
 
+
+
+
     Extractor.prototype.isSupportedByStrategy = function (strategy, extension) {
         return (extension in this.options.extensions) && (this.options.extensions[extension] === strategy);
     };
@@ -377,6 +405,9 @@ var Extractor = (function () {
         }
         if (this.isSupportedByStrategy('js', extension)) {
             this.extractJs(filename, content);
+        }
+        if (this.isSupportedByStrategy('c#', extension)) {
+            this.extractCs(filename, content);
         }
     };
 

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -303,7 +303,7 @@ var Extractor = (function () {
                 }
             };
         };
-        var pattern = /_translate_\s*=\s*"(.*?)"/g;
+        var pattern = /_translate\s*=\s*"(.*?)"/g;
         var match;
         while ((match = pattern.exec(src))) {
             self.addString(reference(match.index), match[1]);

--- a/test/extract_csharp.js
+++ b/test/extract_csharp.js
@@ -4,7 +4,7 @@ var assert = require('assert');
 var testExtract = require('./utils').testExtract;
 
 describe('Extracting from C#', function () {
-    it('should extract the properties having _translate_ sufix', function () {
+    it('should extract the properties having _translate sufix', function () {
         var files = [
             'test/fixtures/Constants.cs'
         ];

--- a/test/extract_csharp.js
+++ b/test/extract_csharp.js
@@ -1,0 +1,21 @@
+﻿'use strict';
+
+var assert = require('assert');
+var testExtract = require('./utils').testExtract;
+
+describe('Extracting from C#', function () {
+    it('should extract the properties having _translate_ sufix', function () {
+        var files = [
+            'test/fixtures/Constants.cs'
+        ];
+        var catalog = testExtract(files);
+
+        assert.equal(catalog.items.length, 2);
+        assert.equal(catalog.items[0].msgid, 'Successfully saved!');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.equal(catalog.items[1].msgid, 'The selected items were deleted successfully.');
+        assert.equal(catalog.items[1].msgstr, '');
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/Constants.cs:14']);
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/Constants.cs:16']);
+    });
+});

--- a/test/fixtures/Constants.cs
+++ b/test/fixtures/Constants.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+
+
+namespace Core.Common
+{
+    public static class Constants
+    {
+
+        public static class Messages
+        {
+            public const string SuccessfullySaved_translate_       = 
+                  "Successfully saved!"           ; 
+            public const string OccurrencesDeleted_translate_ =            "The selected items were deleted successfully."   ;
+            public const string StatusUpdated = "Investigation status was updated successfully.";
+
+            public static class EmailGroupsMessages
+            {
+                public const string EmailGroupDeleted = "Email Group successfully deleted!";
+                public const string EmailUpdated = "Email successfully updated!";
+                public const string EmailDeleted = "Email successfully deleted!";
+            }
+        }
+      
+    }
+}
+
+

--- a/test/fixtures/Constants.cs
+++ b/test/fixtures/Constants.cs
@@ -11,9 +11,9 @@ namespace Core.Common
 
         public static class Messages
         {
-            public const string SuccessfullySaved_translate_       = 
+            public const string SuccessfullySaved_translate       = 
                   "Successfully saved!"           ; 
-            public const string OccurrencesDeleted_translate_ =            "The selected items were deleted successfully."   ;
+            public const string OccurrencesDeleted_translate =            "The selected items were deleted successfully."   ;
             public const string StatusUpdated = "Investigation status was updated successfully.";
 
             public static class EmailGroupsMessages


### PR DESCRIPTION
I extended the actual implementation to extract keys from .cs files that are marked with "_translate" suffix (ex.   public const string SuccessfullySaved_translate = "Successfully saved!";). This is useful when you want to have a single ".po" file for either client side and server side. I also extended the compile command and now generates also a  .cs file having a dictionary with all the translations available in the generated .js file. So you can translate on the server side using Translations.Translate(key) method.  I created the extract_csharp.js test  file to test the extraction of the keys with _translate suffix. For compile, i don't have any idea how to test the generated .cs dictionary in javascript and if you have any suggestions it will be great for me. Hope this is an interesting feature for other people then me!