### PR TITLE
prioritize attribute extraction over html content.

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -345,8 +345,8 @@ var Extractor = (function () {
 
                     if (possibleAttributes.indexOf(attr) > -1) {
                         var attrValue = extracted[attr];
-                        str = node.html(); // this shouldn't be necessary, but it is
-                        self.addString(reference(n.startIndex), str || getAttr(attr) || '', attrValue.plural, attrValue.extractedComment, attrValue.context);
+                        str = getAttr(attr);
+                        self.addString(reference(n.startIndex), str || node.html() || '', attrValue.plural, attrValue.extractedComment, attrValue.context);
                     } else if (matches = noDelimRegex.exec(node.attr(attr))) {
                         str = matches[2].replace(/\\\'/g, '\'');
                         self.addString(reference(n.startIndex), str);


### PR DESCRIPTION
A quick fix based on my question in the main repo: https://github.com/rubenv/angular-gettext/issues/246

Assuming we have `tooltip` attribute added into grunt config `options.attributes`:

```
<!-- Extracts "text1" -->
<x tooltip="text1"></x>


<!-- Extracts "text1" -->
<x tooltip="text1">text2</x>

<!-- Extracts "text1" and "text2" -->
<x tooltip="text1" translate>text2</x>
```

And we can combine `attr-n`, `attr-plural`, `attr-context` and `attr-comment` with translate, but it is not related to this fix:

```
<x tooltip-n="personCount" tooltip-plural="{{$tooltipCount}} people" tooltip="1 person" 
     translate-n="penCount" translate-plural="{{$count}} pens"> 1 pen
</x>
```

As you can see, I have used `$tooltipCount` instead of `$count` for tooltip attribute because they use the same scope and those properties of scope would override each other's value if they had the same name. Also this example assumes someone created a custom directive for `tooltip` attribute.
