### PR TITLE
Revert "Change RegExp for extract strings in nested filter"

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -17,10 +17,10 @@ function mkAttrRegex(startDelim, endDelim) {
         start = '^';
     } else {
         // match optional :: (Angular 1.3's bind once syntax) without capturing
-        start = '[' + start + '|\\(]' + '(?:\\s*\\:\\:\\s*)?';
+        start += '(?:\\s*\\:\\:\\s*)?';
     }
 
-    return new RegExp(start + '\\s*(\'|"|&quot;|&#39;)(.*?)\\1\\s*\\|\\s*translate\\s*(' + end + '|\\||\\))', 'g');
+    return new RegExp(start + '\\s*(\'|"|&quot;|&#39;)(.*?)\\1\\s*\\|\\s*translate\\s*(' + end + '|\\|)', 'g');
 }
 
 var noDelimRegex = mkAttrRegex('', '');

--- a/test/extract_regex.js
+++ b/test/extract_regex.js
@@ -203,18 +203,4 @@ describe('Extract: Filter regex', function () {
         matches = regex.exec('{{\'Hello\' | translate}}');
         assert.equal(matches, null);
     });
-
-    it('Can be used as nested filter', function () {
-        var matches;
-        var regex = mkAttrRegex('{{', '}}');
-        var hit = false;
-
-        while (matches = regex.exec('{{ myModel || (\'Hello\' | translate) }}')) {
-            assert.equal(matches.length, 4);
-            assert.equal(matches[2], 'Hello');
-            hit = true;
-        }
-        assert(hit);
-    });
 });
-


### PR DESCRIPTION
Reverts rubenv/angular-gettext-tools#122

Breaks big one-line HTML extraction.