### PR TITLE
Update lodash dependency to v4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "binary-search": "^1.2.0",
     "cheerio": "~0.19.0",
     "espree": "^2.0.0",
-    "lodash": "^3.10.0",
+    "lodash": "^4.0.0",
     "pofile": "~1.0.0"
   }
 }


### PR DESCRIPTION
This updates the lodash dependency to version `^4.0.0`. Nothing urgent, just trying to avoid duplicates in node_modules/ :) (Yes, I’ve run the tests & looked at the places where lodash is used in the code, no changes required there)