### PR TITLE
Fixes an issue: Did not pick up translate-context annotations in <translate> elements

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -339,7 +339,7 @@ var Extractor = (function () {
                 }
 
                 if (node.is('translate')) {
-                    self.addString(reference(n.startIndex), str, extracted.translate.plural, extracted.translate.extractedComment);
+                    self.addString(reference(n.startIndex), str, extracted.translate.plural, extracted.translate.extractedComment, extracted.translate.context);
                     return;
                 }
 


### PR DESCRIPTION
If you had

<translate translate-context="some context..">Hello</translate>

Then, the context was not picked up.

With:
<div translate translate-context="Hello">....</div>

it works though.