### PR TITLE
Fix hard coded element name

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -341,8 +341,8 @@ var Extractor = (function () {
                     }
                 }
 
-                if (node.is('translate')) {
-                    self.addString(reference(n.startIndex), str, extracted.translate.plural, extracted.translate.extractedComment);
+                if (node.is(self.options.attribute)) {
+                    self.addString(reference(n.startIndex), str, extracted[self.options.attribute].plural, extracted[self.options.attribute].extractedComment, extracted[self.options.attribute].context);
                     return;
                 }
 

--- a/test/extract.js
+++ b/test/extract.js
@@ -349,6 +349,33 @@ describe('Extract', function () {
         assert.equal(catalog.items[1].msgctxt, 'male');
     });
 
+    it('Should extract context of custom element attribute from HTM, including attribute as element', function () {
+        var files = [
+            'test/fixtures/context-custom.html'
+        ];
+        var catalog = testExtract(files, {
+            attribute: 'trans'
+        });
+
+        assert.equal(catalog.items.length, 4);
+
+        assert.equal(catalog.items[0].msgid, 'CrazyMe!');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.equal(catalog.items[0].msgctxt, 'male');
+
+        assert.equal(catalog.items[1].msgid, 'CrazyYou!');
+        assert.equal(catalog.items[1].msgstr, '');
+        assert.strictEqual(catalog.items[1].msgctxt, null);
+
+        assert.equal(catalog.items[2].msgid, 'Hello1!');
+        assert.equal(catalog.items[2].msgstr, '');
+        assert.strictEqual(catalog.items[2].msgctxt, null);
+
+        assert.equal(catalog.items[3].msgid, 'Hello2!');
+        assert.equal(catalog.items[3].msgstr, '');
+        assert.equal(catalog.items[3].msgctxt, 'male');
+    });
+
     it('Extracts strings from an ES6 class', function () {
         var files = [
             'test/fixtures/es6-class.js'

--- a/test/fixtures/context-custom.html
+++ b/test/fixtures/context-custom.html
@@ -1,0 +1,6 @@
+<div>
+    <trans trans-context="male">CrazyMe!</trans>
+    <trans>CrazyYou!</trans>
+    <div trans>Hello1!</div>
+    <div trans trans-context="male">Hello2!</div>
+</div>


### PR DESCRIPTION
It didn't extract elements with custom name, as there is only one option named "attribute" it should be used for custom element names as well. If I were writing an angular directive I'd write only one that would work as an attribute and an element. Tests coming up...