### PR TITLE
Added support for handling multiple filters that seemed to be missing.

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -9,7 +9,7 @@ var _ = require('lodash');
 var escapeRegex = /[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g;
 var noContext = '$$noContext';
 
-function mkAttrRegex(startDelim, endDelim, attribute) {
+function mkAttrRegex(startDelim, endDelim, attributes) {
     var start = startDelim.replace(escapeRegex, '\\$&');
     var end = endDelim.replace(escapeRegex, '\\$&');
 
@@ -20,11 +20,11 @@ function mkAttrRegex(startDelim, endDelim, attribute) {
         start += '(?:\\s*\\:\\:\\s*)?';
     }
 
-    if (!_.isString(attribute) || attribute.length === 0) {
-        attribute = 'translate';
+    if (typeof attributes === 'undefined') {
+    	attributes = ['translate'];
     }
-
-    return new RegExp(start + '\\s*(\'|"|&quot;|&#39;)(.*?)\\1\\s*\\|\\s*' + attribute + '\\s*(' + end + '|\\|)', 'g');
+    
+    return new RegExp(start + '\\s*(\'|"|&quot;|&#39;)(.*?)\\1\\s*\\|\\s*('+attributes.join('|')+')\\s*(' + end + '|\\|)', 'g');
 }
 
 function localeCompare(a, b) {
@@ -92,8 +92,8 @@ var Extractor = (function () {
         this.options.attributes.unshift(this.options.attribute);
 
         this.strings = {};
-        this.attrRegex = mkAttrRegex(this.options.startDelim, this.options.endDelim, this.options.attribute);
-        this.noDelimRegex = mkAttrRegex('', '', this.options.attribute);
+        this.attrRegex = mkAttrRegex(this.options.startDelim, this.options.endDelim, this.options.attributes);
+        this.noDelimRegex = mkAttrRegex('', '', this.options.attributes);
     }
 
     Extractor.isValidStrategy = function (strategy) {

--- a/test/extract.js
+++ b/test/extract.js
@@ -404,4 +404,21 @@ describe('Extract', function () {
         assert.equal(catalog.items[1].msgid, 'Hello!');
         assert.equal(catalog.items[1].msgstr, '');
     });
+
+    it('Should extract multiple filters', function () {
+        var files = [
+            'test/fixtures/multiple-filters.html'
+        ];
+        var catalog = testExtract(files, {
+            attributes: ['normalTranslate', 'specialTranslate']
+        });
+
+        assert.equal(catalog.items.length, 2);
+
+        assert.equal(catalog.items[0].msgid, 'Normal translate');
+        assert.equal(catalog.items[0].msgstr, '');
+
+        assert.equal(catalog.items[1].msgid, 'Special translate');
+        assert.equal(catalog.items[1].msgstr, '');
+    });
 });

--- a/test/extract_regex.js
+++ b/test/extract_regex.js
@@ -15,7 +15,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{\'Hello\'|translate}}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -27,7 +27,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{\'Hello\'|translate|lowercase}}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -39,7 +39,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{"Hello"|translate}}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -51,7 +51,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{\'Hello\'|translate|lowercase}}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -64,10 +64,10 @@ describe('Extract: Filter regex', function () {
 
         while (matches = regex.exec('{{\'Hello\'|translate}} {{"Second"|translate}}')) {
             if (hit === 0) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Hello');
             } else if (hit === 1) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Second');
             }
             hit++;
@@ -81,10 +81,10 @@ describe('Extract: Filter regex', function () {
 
         while (matches = regex.exec('{{\'Hello\'|translate|lowercase}} {{"Second"|translate|uppercase}}')) {
             if (hit === 0) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Hello');
             } else if (hit === 1) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Second');
             }
             hit++;
@@ -98,10 +98,10 @@ describe('Extract: Filter regex', function () {
 
         while (matches = regex.exec('{{\'Hello\'|translate}} {{&quot;Second&quot;|translate}}')) {
             if (hit === 0) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Hello');
             } else if (hit === 1) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Second');
             }
             hit++;
@@ -115,10 +115,10 @@ describe('Extract: Filter regex', function () {
 
         while (matches = regex.exec('{{\'Hello\'|translate}} {{&quot;Second&quot;|translate|lowercase}}')) {
             if (hit === 0) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Hello');
             } else if (hit === 1) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Second');
             }
             hit++;
@@ -131,7 +131,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{ "Hello" | translate }}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -143,7 +143,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{ "Hello" | translate | lowercase }}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -156,7 +156,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('[[\'Hello\'|translate]]')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -169,7 +169,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('[[\'Hello\'|translate|lowercase]]')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -182,7 +182,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('\'Hello\' | translate')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -195,7 +195,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('\'Hello\' | translate | lowercase')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }

--- a/test/fixtures/multiple-filters.html
+++ b/test/fixtures/multiple-filters.html
@@ -1,0 +1,6 @@
+<html>
+    <body>
+        <input type="text" placeholder="{{ 'Normal translate' | normalTranslate }}" />
+        <span>{{ 'Special translate' | specialTranslate }}</span>
+    </body>
+</html>


### PR DESCRIPTION
I noticed that there was support for having an array of translation attributes for HTML tags, but not inside angular filters. So instead of using the initial single `attribute` in `mkAttrRegex` (that was previously hardcoded btw), it now uses the `attributes` array that can be specified as an option to the `Extractor`. This change is useful when having two different angular filters that both should be picked up and extracted for translation.