### PR TITLE
Fix value priority order for custom translation attribute extraction

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -352,7 +352,7 @@ var Extractor = (function () {
                     if (possibleAttributes.indexOf(attr) > -1) {
                         var attrValue = extracted[attr];
                         str = node.html(); // this shouldn't be necessary, but it is
-                        self.addString(reference(n.startIndex), str || getAttr(attr) || '', attrValue.plural, attrValue.extractedComment, attrValue.context);
+                        self.addString(reference(n.startIndex), getAttr(attr) || str || '', attrValue.plural, attrValue.extractedComment, attrValue.context);
                     } else if (matches = self.noDelimRegex.exec(node.attr(attr))) {
                         str = matches[2].replace(/\\\'/g, '\'');
                         self.addString(reference(n.startIndex), str);


### PR DESCRIPTION
When using a custom directive on an attribute, the extracted string should default to the value of the attribute, and if not present, fallback to the HTML inside the tag. For example, if I want to translate all my 'tooltip' attributes, and have some HTML like this:

<span tooltip="translate this">Not this</span>

The old extract.js would extract "Not this" instead. This change fixes this, while allowing "Not this" to be translated if desired by giving the attribute no value.