### PR TITLE
Make export format user customizable.

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -5,8 +5,8 @@ var _ = require('lodash');
 
 var formats = {
     javascript: {
-        addLocale: function (locale, strings) {
-            return '    gettextCatalog.setStrings(\'' + locale + '\', ' + JSON.stringify(strings) + ');\n';
+        addLocale: function (locale, strings, options) {
+            return '    gettextCatalog.setStrings(\'' + locale + '\', ' + JSON.stringify(strings, null, '      ') + ');\n';
         },
         format: function (locales, options) {
             var module = 'angular.module(\'' + options.module + '\')' +
@@ -27,7 +27,7 @@ var formats = {
         }
     },
     json: {
-        addLocale: function (locale, strings) {
+        addLocale: function (locale, strings, options) {
             return {
                 name: locale,
                 strings: strings
@@ -42,6 +42,14 @@ var formats = {
                 _.assign(result[locale.name], locale.strings);
             });
             return JSON.stringify(result);
+        }
+    },
+    template: {
+        addLocale: function (locale, strings, options) {
+            return options.templateAddLocale(locale, strings, options);
+        },
+        format: function (locales, options) {
+            return options.templateFormat(locales, options);
         }
     }
 };
@@ -104,6 +112,7 @@ var Compiler = (function () {
 
     Compiler.prototype.convertPo = function (inputs) {
         var format = formats[this.options.format];
+        var options = this.options;
         var locales = [];
 
         inputs.forEach(function (input) {
@@ -146,10 +155,10 @@ var Compiler = (function () {
                 }
             }
 
-            locales.push(format.addLocale(catalog.headers.Language, strings));
+            locales.push(format.addLocale(catalog.headers.Language, strings, options));
         });
 
-        return format.format(locales, this.options);
+        return format.format(locales, options);
     };
 
     return Compiler;


### PR DESCRIPTION
The generated formats (json, javascript) are not a good fit to my needs:
- I'd like to generate a typescript file that follows my project style.
- I'd like to have each translation followed by a new line, because it makes merges easier.

This could be solved by providing an extra format option where the user provides functions that generate the required format.

Pull request is a quick implementation of that. Using the angular-gettext-tools, one could use something like the following for the configuration of "options":

```
        {
            format: "template",
            templateAddLocale: function(locale, strings, options) {
                let result =
`        gettextCatalog.setStrings(
            "${locale}",
${JSON.stringify(strings, null, '    ').split('\n').map((x) => "            " + x).join('\n')});
`;
                return result;
            },
            templateFormat: function(locales, options) {
                let result = 
`import "angular";
import "angular-gettext";

angular.module("${options.module}").run([
    "gettextCatalog", (gettextCatalog: any) => {
${locales.join('')}
    }
]);
`;
                return result;
            }
        }
```