### PR TITLE
Cannot use translate filter in data attributes

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -353,7 +353,7 @@ var Extractor = (function () {
                         var attrValue = extracted[attr];
                         str = node.html(); // this shouldn't be necessary, but it is
                         self.addString(reference(n.startIndex), str || getAttr(attr) || '', attrValue.plural, attrValue.extractedComment, attrValue.context);
-                    } else if (matches = self.noDelimRegex.exec(node.attr(attr))) {
+                    } else if (matches = self.noDelimRegex.exec(getAttr(attr))) {
                         str = matches[2].replace(/\\\'/g, '\'');
                         self.addString(reference(n.startIndex), str);
                         self.noDelimRegex.lastIndex = 0;

--- a/test/extract_filters.js
+++ b/test/extract_filters.js
@@ -82,7 +82,7 @@ describe('Extracting filters', function () {
         assert.equal(catalog.items[3].msgstr, '');
         assert.deepEqual(catalog.items[3].references, ['test/fixtures/filter-in-multiple-expression-attributes.html:3']);
     });
-    
+
     it('works for the data attribute case', function () {
         var files = [
             'test/fixtures/filter-data-attributes.html'

--- a/test/extract_filters.js
+++ b/test/extract_filters.js
@@ -82,4 +82,23 @@ describe('Extracting filters', function () {
         assert.equal(catalog.items[3].msgstr, '');
         assert.deepEqual(catalog.items[3].references, ['test/fixtures/filter-in-multiple-expression-attributes.html:3']);
     });
+    
+    it('works for the data attribute case', function () {
+        var files = [
+            'test/fixtures/filter-data-attributes.html'
+        ];
+        var catalog = testExtract(files);
+
+        assert.equal(catalog.items.length, 2);
+        
+        assert.equal(catalog.items[0].msgid, 'LabelAttribute');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.equal(catalog.items[0].references.length, 1);
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/filter-data-attributes.html:3']);
+
+        assert.equal(catalog.items[1].msgid, 'DataLabelAttribute');
+        assert.equal(catalog.items[1].msgstr, '');
+        assert.equal(catalog.items[1].references.length, 1);
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/filter-data-attributes.html:4']);
+    });
 });

--- a/test/extract_filters.js
+++ b/test/extract_filters.js
@@ -89,16 +89,26 @@ describe('Extracting filters', function () {
         ];
         var catalog = testExtract(files);
 
-        assert.equal(catalog.items.length, 2);
+        assert.equal(catalog.items.length, 4);
 
-        assert.equal(catalog.items[0].msgid, 'expr1');
+        assert.equal(catalog.items[0].msgid, 'label1');
         assert.equal(catalog.items[0].msgstr, '');
         assert.equal(catalog.items[0].references.length, 1);
         assert.deepEqual(catalog.items[0].references, ['test/fixtures/filter-data-attributes.html:3']);
 
-        assert.equal(catalog.items[1].msgid, 'expr2');
+        assert.equal(catalog.items[1].msgid, 'label2');
         assert.equal(catalog.items[1].msgstr, '');
         assert.equal(catalog.items[1].references.length, 1);
         assert.deepEqual(catalog.items[1].references, ['test/fixtures/filter-data-attributes.html:4']);
+
+        assert.equal(catalog.items[2].msgid, 'label3');
+        assert.equal(catalog.items[2].msgstr, '');
+        assert.equal(catalog.items[2].references.length, 1);
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/filter-data-attributes.html:5']);
+
+        assert.equal(catalog.items[3].msgid, 'label4');
+        assert.equal(catalog.items[3].msgstr, '');
+        assert.equal(catalog.items[3].references.length, 1);
+        assert.deepEqual(catalog.items[3].references, ['test/fixtures/filter-data-attributes.html:6']);
     });
 });

--- a/test/extract_filters.js
+++ b/test/extract_filters.js
@@ -91,12 +91,12 @@ describe('Extracting filters', function () {
 
         assert.equal(catalog.items.length, 2);
 
-        assert.equal(catalog.items[0].msgid, 'LabelAttribute');
+        assert.equal(catalog.items[0].msgid, 'expr1');
         assert.equal(catalog.items[0].msgstr, '');
         assert.equal(catalog.items[0].references.length, 1);
         assert.deepEqual(catalog.items[0].references, ['test/fixtures/filter-data-attributes.html:3']);
 
-        assert.equal(catalog.items[1].msgid, 'DataLabelAttribute');
+        assert.equal(catalog.items[1].msgid, 'expr2');
         assert.equal(catalog.items[1].msgstr, '');
         assert.equal(catalog.items[1].references.length, 1);
         assert.deepEqual(catalog.items[1].references, ['test/fixtures/filter-data-attributes.html:4']);

--- a/test/extract_filters.js
+++ b/test/extract_filters.js
@@ -90,7 +90,7 @@ describe('Extracting filters', function () {
         var catalog = testExtract(files);
 
         assert.equal(catalog.items.length, 2);
-        
+
         assert.equal(catalog.items[0].msgid, 'LabelAttribute');
         assert.equal(catalog.items[0].msgstr, '');
         assert.equal(catalog.items[0].references.length, 1);

--- a/test/fixtures/filter-data-attributes.html
+++ b/test/fixtures/filter-data-attributes.html
@@ -1,0 +1,6 @@
+<html>
+    <body>
+        <input type="text" label="{{'LabelAttribute'|translate}}" />
+        <input type="text" data-label="{{'DataLabelAttribute'|translate}}" />
+    </body>
+</html>

--- a/test/fixtures/filter-data-attributes.html
+++ b/test/fixtures/filter-data-attributes.html
@@ -1,6 +1,8 @@
 <html>
     <body>
-        <input type="text" label="{{'expr1'|translate}}" />
-        <input type="text" data-label="{{'expr2'|translate}}" />
+        <input attr="'label1' | translate" />
+        <input data-attr="'label2' | translate" />
+        <input attr1="'label3' | translate" />
+        <input data-attr2="'label4' | translate" />
     </body>
 </html>

--- a/test/fixtures/filter-data-attributes.html
+++ b/test/fixtures/filter-data-attributes.html
@@ -1,6 +1,6 @@
 <html>
     <body>
-        <input type="text" label="{{'LabelAttribute'|translate}}" />
-        <input type="text" data-label="{{'DataLabelAttribute'|translate}}" />
+        <input type="text" label="{{'expr1'|translate}}" />
+        <input type="text" data-label="{{'expr2'|translate}}" />
     </body>
 </html>


### PR DESCRIPTION
With these two following attribute syntaxes "stringToTranslate" should be parsed, but not with data attribute.
```
<component-markup label="'stringToTranslate' | translate"></component-markup>
<component-markup data-label="'stringToTranslate' | translate"></component-markup>
``` 
the second one is never parsed but still valid angular syntax