### PR TITLE
Update espree dependency to ^3.0.0

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -169,31 +169,12 @@ var Extractor = (function () {
         var syntax;
         try {
             syntax = espree.parse(src, {
-                tolerant: true,
                 attachComment: true,
                 loc: true,
+                ecmaVersion: 6,
                 ecmaFeatures: {
-                    arrowFunctions: true,
-                    blockBindings: true,
-                    destructuring: true,
-                    regexYFlag: true,
-                    regexUFlag: true,
-                    templateStrings: true,
-                    binaryLiterals: true,
-                    octalLiterals: true,
-                    unicodeCodePointEscapes: true,
-                    defaultParams: true,
-                    restParams: true,
-                    forOf: true,
-                    objectLiteralComputedProperties: true,
-                    objectLiteralShorthandMethods: true,
-                    objectLiteralShorthandProperties: true,
-                    objectLiteralDuplicateProperties: true,
-                    generators: true,
-                    spread: true,
-                    classes: true,
-                    modules: true,
                     jsx: true,
+                    experimentalObjectRestSpread: true,
                     globalReturn: true
                 }
             });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "binary-search": "^1.2.0",
     "cheerio": "~0.19.0",
-    "espree": "^2.0.0",
+    "espree": "^3.0.0",
     "lodash": "^4.0.0",
     "pofile": "~1.0.0"
   }


### PR DESCRIPTION
Modified the options that are passed to espree to be up to date with the latest version of it. It looks like it pulled most of the options in by default.

I had to forcefully set to use ec6 features so the class test passed.

All tests pass.

I had to do this because there was an error with the v2 branch of Espree that was randomly failing while parsing some of my source code and I didn't realize that I lost translations when extracting. Upgrading seems to extract correctly on my project.