### PR TITLE
Output error message on espree error

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -179,6 +179,16 @@ var Extractor = (function () {
                 }
             });
         } catch (err) {
+            var errMsg = 'Error parsing';
+            if (filename) {
+                errMsg += ' ' + filename;
+            }
+            if (err.lineNumber) {
+                errMsg += ' at line ' + err.lineNumber;
+                errMsg += ' column ' + err.column;
+            }
+
+            console.warn(errMsg);
             return;
         }
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "grunt-contrib-jshint": "~0.11.2",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-jscs": "^1.8.0",
-    "grunt-mocha-cli": "^1.13.1"
+    "grunt-mocha-cli": "^1.13.1",
+    "sinon": "^1.17.4"
   },
   "keywords": [
     "angular",

--- a/test/extract_javascript.js
+++ b/test/extract_javascript.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var assert = require('assert');
+var sinon = require('sinon');
 var testExtract = require('./utils').testExtract;
 
 describe('Extracting from Javascript', function () {
@@ -78,11 +79,23 @@ describe('Extracting from Javascript', function () {
         assert.deepEqual(catalog.items[1].references, ['test/fixtures/deeppath_catalog.js:4']);
     });
 
-    it('supports invalid javascript syntax without exception', function () {
-        var files = [
-            'test/fixtures/deeppath_catalog_invalid.js'
-        ];
-        testExtract(files);
+    describe('invalid javascript', function () {
+        beforeEach(function () {
+            sinon.stub(console, 'warn', function () {
+                // respect the rule of silence
+            });
+        });
+
+        afterEach(function () {
+            console.warn.restore();
+        });
+
+        it('should not throw an exception', function () {
+            var files = [
+                'test/fixtures/deeppath_catalog_invalid.js'
+            ];
+            testExtract(files);
+        });
     });
 
     describe('from HTML <script> tags', function () {


### PR DESCRIPTION
Don't silently continue on when we encounter an espree error. Instead, output the location of the parse error, then continue on.

See #140. 