### PR TITLE
add removeWhiteSpaces option to remove spaces from msgids in compile

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -104,6 +104,7 @@ var Compiler = (function () {
 
     Compiler.prototype.convertPo = function (inputs) {
         var format = formats[this.options.format];
+        var removeWhiteSpaces = this.options.removeWhiteSpaces;
         var locales = [];
 
         inputs.forEach(function (input) {
@@ -127,6 +128,10 @@ var Compiler = (function () {
                     convertedEntity = Compiler.browserConvertedHTMLEntities[ unconvertedEntity ];
                     unconvertedEntityPattern = new RegExp( '&' + unconvertedEntity + ';?', 'g' );
                     msgid = msgid.replace( unconvertedEntityPattern, convertedEntity );
+                }
+
+                if ( removeWhiteSpaces ) {
+                    msgid = msgid.replace( /\s+/g, ' ' );
                 }
 
                 if (item.msgstr[0].length > 0 && !item.flags.fuzzy && !item.obsolete) {

--- a/test/compile.js
+++ b/test/compile.js
@@ -193,6 +193,35 @@ describe('Compile', function () {
         });
     });
 
+    it('Remove spaces', function () {
+        var files = ['test/fixtures/spaces.po'];
+        var output = testCompile(files, {
+            format: 'json',
+            removeWhiteSpaces: true
+        });
+        var data = JSON.parse(output);
+
+        assert.deepEqual(data.fr, {
+            'Hello!': 'Bonjour!',
+            'This is a test': 'Ceci est un test',
+            'Bird': ['Oiseau', 'Oiseaux']
+        });
+    });
+
+    it('Do not remove spaces', function () {
+        var files = ['test/fixtures/spaces.po'];
+        var output = testCompile(files, {
+            format: 'json'
+        });
+        var data = JSON.parse(output);
+
+        assert.deepEqual(data.fr, {
+            'Hello!': 'Bonjour!',
+            'This           is\n         a test': 'Ceci est un test',
+            'Bird': ['Oiseau', 'Oiseaux']
+        });
+    });
+
     it('Can output multiple inputs to single JSON', function () {
         var files = ['test/fixtures/fr.po', 'test/fixtures/depth/fr.po'];
         var output = testCompile(files, {

--- a/test/fixtures/spaces.po
+++ b/test/fixtures/spaces.po
@@ -1,0 +1,27 @@
+msgid ""
+msgstr ""
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n>1;\n"
+"Project-Id-Version: \n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"X-Generator: Poedit 1.5.7\n"
+
+#: test/fixtures/single.html test/fixtures/second.html
+msgid "Hello!"
+msgstr "Bonjour!"
+
+#: test/fixtures/second.html
+msgid "This           is\n         a test"
+msgstr "Ceci est un test"
+
+#: test/fixtures/plural.html
+msgid "Bird"
+msgid_plural "Birds"
+msgstr[0] "Oiseau"
+msgstr[1] "Oiseaux"


### PR DESCRIPTION
@rubenv Can you review this PR please?

I added an option to `compile` so that it can remove whitespaces from `msgid`. 

**Why do we need this?**
When we compile angular templates, all the whitespaces are also removed. So some of the strings don't match with the ones in translation dictionary. 

**Example**
angular template:
```html
<div translate>Hello
               World</div>
```

translation dictionary:
```js
{
  ...
  "Hello\n      World": "..."
  ...
}
```

compiled template:
```html
<div translate>Hello World</div>
```

translation dictionary if `removeWhiteSpaces` option is set to `true`:
```js
{
  ...
  "Hello World": "..."
  ...
}
```
