### PR TITLE
Add *.po file headers

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -86,6 +86,7 @@ var Extractor = (function () {
                 tag: 'html',
                 jsp: 'html'
             },
+            headers:{},
             postProcess: function (po) {}
         }, options);
         this.options.markerNames.unshift(this.options.markerName);
@@ -381,11 +382,11 @@ var Extractor = (function () {
     Extractor.prototype.toString = function () {
         var catalog = new Po();
 
-        catalog.headers = {
+        catalog.headers = _.extend({
             'Content-Type': 'text/plain; charset=UTF-8',
             'Content-Transfer-Encoding': '8bit',
             'Project-Id-Version': ''
-        };
+        }, this.options.headers);
 
         for (var msgstr in this.strings) {
             var msg = this.strings[msgstr];


### PR DESCRIPTION
Extend hardcoded headers for *.po file
```javascript
grunt.initConfig({
  nggettext_extract: {
    pot: {
      options:{
        headers: {
          'Language': 'en_US'
        }
      },
      files: {
        'po/template.pot': ['src/views/*.html']
      }
    },
  },
})
````