### PR TITLE
Add ability to add context to custom attributes at 'translate' filter

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -61,6 +61,18 @@ function getJSExpression(node) {
     return res;
 }
 
+function parseContext(str) {
+    return str
+        .split(':')[1]
+        .trim()
+        .replace(/^"(.*)"$/, '$1')
+        .replace(/^'(.*)'$/, '$1');
+}
+
+function getContextFromFilter(str) {
+    return str.indexOf(':') + 1 ? parseContext(str) : null;
+}
+
 var Extractor = (function () {
     function Extractor(options) {
         this.options = _.extend({
@@ -346,8 +358,10 @@ var Extractor = (function () {
                         str = node.html(); // this shouldn't be necessary, but it is
                         self.addString(reference(n.startIndex), str || getAttr(attr) || '', attrValue.plural, attrValue.extractedComment, attrValue.context);
                     } else if (matches = self.noDelimRegex.exec(getAttr(attr))) {
+                        var context = getContextFromFilter(matches.input);
+
                         str = matches[2].replace(/\\\'/g, '\'');
-                        self.addString(reference(n.startIndex), str);
+                        self.addString(reference(n.startIndex), str, null, null, context);
                         self.noDelimRegex.lastIndex = 0;
                     }
                 }

--- a/test/extract_filters.js
+++ b/test/extract_filters.js
@@ -111,4 +111,43 @@ describe('Extracting filters', function () {
         assert.equal(catalog.items[3].references.length, 1);
         assert.deepEqual(catalog.items[3].references, ['test/fixtures/filter-data-attributes.html:6']);
     });
+
+    it('works with context at attributes', function () {
+        var files = [
+            'test/fixtures/filter-attr-context.html'
+        ];
+        var catalog = testExtract(files);
+
+        assert.equal(catalog.items.length, 5);
+
+        assert.equal(catalog.items[0].msgid, 'Hello1');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.equal(catalog.items[0].msgctxt, 'contextSimple');
+        assert.equal(catalog.items[0].references.length, 1);
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/filter-attr-context.html:3']);
+
+        assert.equal(catalog.items[1].msgid, 'Hello2');
+        assert.equal(catalog.items[1].msgstr, '');
+        assert.equal(catalog.items[1].msgctxt, 'context in singe quotes');
+        assert.equal(catalog.items[1].references.length, 1);
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/filter-attr-context.html:4']);
+
+        assert.equal(catalog.items[2].msgid, 'Hello3');
+        assert.equal(catalog.items[2].msgstr, '');
+        assert.equal(catalog.items[2].msgctxt, 'context in double quotes');
+        assert.equal(catalog.items[2].references.length, 1);
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/filter-attr-context.html:5']);
+
+        assert.equal(catalog.items[3].msgid, 'Hello4');
+        assert.equal(catalog.items[3].msgstr, '');
+        assert.equal(catalog.items[3].msgctxt, 'context with space');
+        assert.equal(catalog.items[3].references.length, 1);
+        assert.deepEqual(catalog.items[3].references, ['test/fixtures/filter-attr-context.html:6']);
+
+        assert.equal(catalog.items[4].msgid, 'Hello5');
+        assert.equal(catalog.items[4].msgstr, '');
+        assert.equal(catalog.items[4].msgctxt, null);
+        assert.equal(catalog.items[4].references.length, 1);
+        assert.deepEqual(catalog.items[4].references, ['test/fixtures/filter-attr-context.html:7']);
+    });
 });

--- a/test/fixtures/filter-attr-context.html
+++ b/test/fixtures/filter-attr-context.html
@@ -1,0 +1,9 @@
+<html>
+    <body>
+        <div custom-attribute="'Hello1'|translate:contextSimple"></div>
+        <div custom-attribute="'Hello2'|translate:'context in singe quotes'"></div>
+        <div custom-attribute='"Hello3"|translate:"context in double quotes"'></div>
+        <div custom-attribute="'Hello4' | translate : 'context with space'"></div>
+        <div custom-attribute="'Hello5'|translate"></div>
+    </body>
+</html>


### PR DESCRIPTION
It may be helpful for example here http://ng-table.com/ at `title="'Name' | translate : context"`
