### PR TITLE
Capture filter translation with context 

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -24,7 +24,7 @@ function mkAttrRegex(startDelim, endDelim, attribute) {
         attribute = 'translate';
     }
 
-    return new RegExp(start + '\\s*(\'|"|&quot;|&#39;)(.*?)\\1\\s*\\|\\s*' + attribute + '\\s*(' + end + '|\\|)', 'g');
+    return new RegExp(start + '\\s*(\'|"|&quot;|&#39;)(.*?)\\1\\s*\\|\\s*' + attribute + '\\s*:?\\s?(?:(\'|"|&quot;|&#39;)\\s*(.*?)\\3)?\\s*(?:' + end + '|\\|)', 'g');
 }
 
 function stringCompare(a, b) {
@@ -356,7 +356,8 @@ var Extractor = (function () {
             var matches;
             while (matches = this.attrRegex.exec(src)) {
                 var str = matches[2].replace(/\\\'/g, '\'');
-                this.addString(reference(matches.index), str);
+                var context = matches[4] ? matches[4].replace(/\\\'/g, '\'') : null;
+                this.addString(reference(matches.index), str, null, null, context);
             }
         }.bind(this);
 

--- a/test/extract_regex.js
+++ b/test/extract_regex.js
@@ -15,7 +15,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{\'Hello\'|translate}}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -27,7 +27,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{\'Hello\'|translate|lowercase}}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -39,7 +39,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{"Hello"|translate}}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -51,7 +51,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{\'Hello\'|translate|lowercase}}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -64,10 +64,10 @@ describe('Extract: Filter regex', function () {
 
         while (matches = regex.exec('{{\'Hello\'|translate}} {{"Second"|translate}}')) {
             if (hit === 0) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Hello');
             } else if (hit === 1) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Second');
             }
             hit++;
@@ -81,10 +81,10 @@ describe('Extract: Filter regex', function () {
 
         while (matches = regex.exec('{{\'Hello\'|translate|lowercase}} {{"Second"|translate|uppercase}}')) {
             if (hit === 0) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Hello');
             } else if (hit === 1) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Second');
             }
             hit++;
@@ -98,10 +98,10 @@ describe('Extract: Filter regex', function () {
 
         while (matches = regex.exec('{{\'Hello\'|translate}} {{&quot;Second&quot;|translate}}')) {
             if (hit === 0) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Hello');
             } else if (hit === 1) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Second');
             }
             hit++;
@@ -115,10 +115,10 @@ describe('Extract: Filter regex', function () {
 
         while (matches = regex.exec('{{\'Hello\'|translate}} {{&quot;Second&quot;|translate|lowercase}}')) {
             if (hit === 0) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Hello');
             } else if (hit === 1) {
-                assert.equal(matches.length, 4);
+                assert.equal(matches.length, 5);
                 assert.equal(matches[2], 'Second');
             }
             hit++;
@@ -131,7 +131,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{ "Hello" | translate }}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -143,7 +143,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('{{ "Hello" | translate | lowercase }}')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -156,7 +156,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('[[\'Hello\'|translate]]')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -169,7 +169,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('[[\'Hello\'|translate|lowercase]]')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -182,7 +182,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('\'Hello\' | translate')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }
@@ -195,7 +195,7 @@ describe('Extract: Filter regex', function () {
         var hit = false;
 
         while (matches = regex.exec('\'Hello\' | translate | lowercase')) {
-            assert.equal(matches.length, 4);
+            assert.equal(matches.length, 5);
             assert.equal(matches[2], 'Hello');
             hit = true;
         }

--- a/test/extract_regex.js
+++ b/test/extract_regex.js
@@ -203,4 +203,19 @@ describe('Extract: Filter regex', function () {
         matches = regex.exec('{{\'Hello\' | translate}}');
         assert.equal(matches, null);
     });
+
+    it('Can be used with filter context', function () {
+        var matches;
+        var regex = mkAttrRegex('', '');
+        var hit = false;
+
+        while (matches = regex.exec('\'Hello\' | translate:"context"')) {
+            assert.equal(matches.length, 5);
+            assert.equal(matches[2], 'Hello');
+            assert.equal(matches[4], 'context');
+            hit = true;
+        }
+
+        assert(hit);
+    });
 });


### PR DESCRIPTION
Hi,

this PR provides support for context used in `translate` filter, e.g. `{{ 'Hello' | translate: 'context' }}`

Kind regards

p.s. Duplicate of #104 #155 
