### PR TITLE
feat: includeFuzzy option, default is false

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ All options and defaults are displayed below:
     "lineNumbers": true,
     "format": "javascript",
     "defaultLanguage": false,
-    "requirejs": false
+    "requirejs": false,
+    "includeFuzzy": false
 }
 ```
 

--- a/lib/compile.js
+++ b/lib/compile.js
@@ -52,7 +52,8 @@ var Compiler = (function () {
     function Compiler(options) {
         this.options = _.extend({
             format: 'javascript',
-            module: 'gettext'
+            module: 'gettext',
+            includeFuzzy: false
         }, options);
     }
 
@@ -103,6 +104,7 @@ var Compiler = (function () {
     };
 
     Compiler.prototype.convertPo = function (inputs) {
+        var includeFuzzy = this.options.includeFuzzy;
         var format = formats[this.options.format];
         var locales = [];
 
@@ -129,7 +131,7 @@ var Compiler = (function () {
                     msgid = msgid.replace( unconvertedEntityPattern, convertedEntity );
                 }
 
-                if (item.msgstr[0].length > 0 && !item.flags.fuzzy && !item.obsolete) {
+                if (item.msgstr[0].length > 0 && (!item.flags.fuzzy || item.flags.fuzzy && includeFuzzy) && !item.obsolete) {
                     if (!strings[msgid]) {
                         strings[msgid] = {};
                     }

--- a/test/compile.js
+++ b/test/compile.js
@@ -193,6 +193,20 @@ describe('Compile', function () {
         });
     });
 
+    it('Includes fuzzy strings', function () {
+        var files = ['test/fixtures/fuzzy.po'];
+        var output = testCompile(files, {
+            format: 'json',
+            includeFuzzy: true
+        });
+        var data = JSON.parse(output);
+
+        assert.deepEqual(data.nl, {
+            'This is a test': 'Dit is een test',
+            'Hello!': 'Dag!'
+        });
+    });
+
     it('Can output multiple inputs to single JSON', function () {
         var files = ['test/fixtures/fr.po', 'test/fixtures/depth/fr.po'];
         var output = testCompile(files, {


### PR DESCRIPTION
Hi there,
I created a PR that provides an ability to enable/disable including of fuzzy translations. The PR comes with the tests too.

It is also related to comments in https://github.com/rubenv/grunt-angular-gettext/issues/34

It is a quite useful when you are using poeditor.com and you do a refactoring of some terms (mainly you fix the wording and so on, and sometimes the meaning can be slightly changed). Such a translation is marked then as fuzzy and it takes time until is fixed. Imagine if you need to support more than 10 languages. So in the meantime,  you are fine with those fuzzy translations.

Before this PR you were  unable to do so and include them, unless you remove from all your po files fuzzy mark, which is too intrusive and you might loose track of fuzzy marks.

Now you can use this gruntfile:

```js
  nggettext_compile: {
        all: {
            options: {
                format: "json",
                includeFuzzy: true
            },
            files: [
                {
                    expand: true,
                    dot: true,
                    cwd: "po",
                    dest: "client/assets/languages",
                    src: ["*.po"],
                    ext: ".json"
                }
            ]
        },
    },
```
Cheers,
Andrej