### PR TITLE
Typescript-eslint-parser & typescript updated

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "cheerio": "~0.19.0",
     "lodash": "^4.0.0",
     "pofile": "~1.0.0",
-    "typescript": "~2.0.3",
-    "typescript-eslint-parser": "^1.0.2"
+    "typescript": "~2.3.2",
+    "typescript-eslint-parser": "^3.0.0"
   }
 }


### PR DESCRIPTION
While working with newer version of Typescript some parts of code are not being processed correctly and other modules like angular-gettext-tools cannot extract text from typescript files