### PR TITLE
Made extraction idempotent thanks to stable sorting of msgs.

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -32,6 +32,15 @@ function stringCompare(a, b) {
     return a === b ? 0 : a > b ? 1 : -1;
 }
 
+function contextCompare(a, b) {
+    if (a !== null && b === null) {
+        return -1;
+    } else if (a === null && b !== null) {
+        return 1;
+    }
+    return stringCompare(a, b);
+}
+
 function comments2String(comments) {
     return comments.join(', ');
 }
@@ -424,17 +433,22 @@ var Extractor = (function () {
             'Project-Id-Version': ''
         };
 
+        var sortedItems = [];
         for (var msgstr in this.strings) {
             var msg = this.strings[msgstr];
-            var contexts = Object.keys(msg).sort();
+            var contexts = Object.keys(msg);
             for (var i = 0; i < contexts.length; i++) {
-                catalog.items.push(msg[contexts[i]]);
+                sortedItems.push([msg[contexts[i]], i]);
             }
         }
 
-        catalog.items.sort(function (a, b) {
-            return stringCompare(a.msgid, b.msgid);
+        sortedItems.sort(function (a, b) {
+            return contextCompare(a[0].msgctxt, b[0].msgctxt) || stringCompare(a[0].msgid, b[0].msgid) || (a[1] - b[1]);
         });
+
+        for (var j = 0; j < sortedItems.length; j++) {
+            catalog.items.push(sortedItems[j][0]);
+        }
 
         this.options.postProcess(catalog);
 

--- a/test/extract.js
+++ b/test/extract.js
@@ -131,15 +131,18 @@ describe('Extract', function () {
         var catalog = testExtract(files);
 
         assert.equal(catalog.items.length, 6);
-        assert.equal(catalog.items[0].msgid, 'a');
-        assert.equal(catalog.items[1].msgid, 'b');
-        assert.equal(catalog.items[2].msgid, 'c');
-        assert.equal(catalog.items[3].msgid, 'd');
+        assert.equal(catalog.items[0].msgid, 'd');
+        assert.equal(catalog.items[0].msgctxt, 'a');
+        assert.equal(catalog.items[1].msgid, 'd');
+        assert.equal(catalog.items[1].msgctxt, 'b');
+        assert.equal(catalog.items[2].msgid, 'a');
+        assert.equal(catalog.items[2].msgctxt, null);
+        assert.equal(catalog.items[3].msgid, 'b');
         assert.equal(catalog.items[3].msgctxt, null);
-        assert.equal(catalog.items[4].msgid, 'd');
-        assert.equal(catalog.items[4].msgctxt, 'a');
+        assert.equal(catalog.items[4].msgid, 'c');
+        assert.equal(catalog.items[4].msgctxt, null);
         assert.equal(catalog.items[5].msgid, 'd');
-        assert.equal(catalog.items[5].msgctxt, 'b');
+        assert.equal(catalog.items[5].msgctxt, null);
     });
 
     it('Extracts strings concatenation from JavaScript source', function () {
@@ -342,11 +345,11 @@ describe('Extract', function () {
 
         assert.equal(catalog.items[0].msgid, 'Hello!');
         assert.equal(catalog.items[0].msgstr, '');
-        assert.strictEqual(catalog.items[0].msgctxt, null);
+        assert.equal(catalog.items[0].msgctxt, 'male');
 
         assert.equal(catalog.items[1].msgid, 'Hello!');
         assert.equal(catalog.items[1].msgstr, '');
-        assert.equal(catalog.items[1].msgctxt, 'male');
+        assert.strictEqual(catalog.items[1].msgctxt, null);
     });
 
     it('Should extract context of custom element attribute from HTM, including attribute as element', function () {
@@ -363,17 +366,17 @@ describe('Extract', function () {
         assert.equal(catalog.items[0].msgstr, '');
         assert.equal(catalog.items[0].msgctxt, 'male');
 
-        assert.equal(catalog.items[1].msgid, 'CrazyYou!');
+        assert.equal(catalog.items[1].msgid, 'Hello2!');
         assert.equal(catalog.items[1].msgstr, '');
-        assert.strictEqual(catalog.items[1].msgctxt, null);
+        assert.equal(catalog.items[1].msgctxt, 'male');
 
-        assert.equal(catalog.items[2].msgid, 'Hello1!');
+        assert.equal(catalog.items[2].msgid, 'CrazyYou!');
         assert.equal(catalog.items[2].msgstr, '');
         assert.strictEqual(catalog.items[2].msgctxt, null);
 
-        assert.equal(catalog.items[3].msgid, 'Hello2!');
+        assert.equal(catalog.items[3].msgid, 'Hello1!');
         assert.equal(catalog.items[3].msgstr, '');
-        assert.equal(catalog.items[3].msgctxt, 'male');
+        assert.strictEqual(catalog.items[3].msgctxt, null);
     });
 
     it('Extracts strings from an ES6 class', function () {

--- a/test/extract_javascript.js
+++ b/test/extract_javascript.js
@@ -44,12 +44,11 @@ describe('Extracting from Javascript', function () {
         var catalog = testExtract(files);
 
         assert.equal(catalog.items.length, 4);
-        assert.equal(catalog.items[0].msgid, 'Bird');
-        assert.equal(catalog.items[0].msgid_plural, 'Birds');
-        assert.equal(catalog.items[0].msgstr.length, 2);
-        assert.equal(catalog.items[0].msgstr[0], '');
-        assert.equal(catalog.items[0].msgstr[1], '');
-        assert.deepEqual(catalog.items[0].references, ['test/fixtures/catalog.js:4']);
+
+        assert.equal(catalog.items[0].msgid, 'Hello2');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.equal(catalog.items[0].msgctxt, 'Context');
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/catalog.js:3']);
 
         assert.equal(catalog.items[1].msgid, 'Bird2');
         assert.equal(catalog.items[1].msgid_plural, 'Birds2');
@@ -59,14 +58,16 @@ describe('Extracting from Javascript', function () {
         assert.equal(catalog.items[1].msgctxt, 'Context2');
         assert.deepEqual(catalog.items[1].references, ['test/fixtures/catalog.js:5']);
 
-        assert.equal(catalog.items[2].msgid, 'Hello');
-        assert.equal(catalog.items[2].msgstr, '');
-        assert.deepEqual(catalog.items[2].references, ['test/fixtures/catalog.js:2']);
+        assert.equal(catalog.items[2].msgid, 'Bird');
+        assert.equal(catalog.items[2].msgid_plural, 'Birds');
+        assert.equal(catalog.items[2].msgstr.length, 2);
+        assert.equal(catalog.items[2].msgstr[0], '');
+        assert.equal(catalog.items[2].msgstr[1], '');
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/catalog.js:4']);
 
-        assert.equal(catalog.items[3].msgid, 'Hello2');
+        assert.equal(catalog.items[3].msgid, 'Hello');
         assert.equal(catalog.items[3].msgstr, '');
-        assert.equal(catalog.items[3].msgctxt, 'Context');
-        assert.deepEqual(catalog.items[3].references, ['test/fixtures/catalog.js:3']);
+        assert.deepEqual(catalog.items[3].references, ['test/fixtures/catalog.js:2']);
     });
 
     it('supports foo.gettextCatalog.getString()', function () {


### PR DESCRIPTION
Before this, running the extraction many times yielded different outputs
which was problematic with version control.