### PR TITLE
Fixes rubenv/angular-gettext-tools#177

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -215,7 +215,7 @@ var Extractor = (function () {
         function isAnnontatedString(node) {
             return node !== null &&
                 isStringLiteral(node) &&
-                node.leadingComments !== null &&
+                node.leadingComments &&
                 self.options.markerNames.some(function (markerName) {
                     return node.leadingComments.some(function (comment) {
                         return comment.value.indexOf(markerName) !== -1;

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -212,6 +212,17 @@ var Extractor = (function () {
             return;
         }
 
+        function isAnnontatedString (node) {
+            return node !== null &&
+                isStringLiteral(node) &&
+                node.leadingComments !== null &&
+                self.options.markerNames.some(function (markerName) {
+                    return node.leadingComments.some(function (comment) {
+                        return comment.value.indexOf(markerName) !== -1;
+                    });
+                });
+        }
+
         function isGettext(node) {
             return node !== null &&
                 node.type === 'CallExpression' &&
@@ -298,6 +309,8 @@ var Extractor = (function () {
             } else if (isTemplateElement(node)) {
                 var line = reference.location && reference.location.start.line ? reference.location.start.line - 1 : 0;
                 self.extractHtml(reference.file, node.value.raw, line);
+            } else if (isAnnontatedString(node)) {
+                str = getJSExpression(node);
             }
             if (str || singular) {
                 var leadingComments = node.leadingComments || (parentComment ? parentComment.leadingComments : []);

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -216,8 +216,8 @@ var Extractor = (function () {
             return node !== null &&
                 isStringLiteral(node) &&
                 node.leadingComments !== null &&
-                self.options.markerNames.some(function(markerName) {
-                    return node.leadingComments.some(function(comment) {
+                self.options.markerNames.some(function (markerName) {
+                    return node.leadingComments.some(function (comment) {
                         return comment.value.indexOf(markerName) !== -1;
                     });
                 });

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -212,12 +212,12 @@ var Extractor = (function () {
             return;
         }
 
-        function isAnnontatedString (node) {
+        function isAnnontatedString(node) {
             return node !== null &&
                 isStringLiteral(node) &&
                 node.leadingComments !== null &&
-                self.options.markerNames.some(function (markerName) {
-                    return node.leadingComments.some(function (comment) {
+                self.options.markerNames.some(function(markerName) {
+                    return node.leadingComments.some(function(comment) {
                         return comment.value.indexOf(markerName) !== -1;
                     });
                 });


### PR DESCRIPTION
Allow using `markerNames` to detect string literals. Simply add a leading comment to the string that contains the `markerName` (exactly) and that string will be added to the `pot` file.

Example:
```js
const myString = /* gettext */ "This will be extracted"
```

or

```js
var extractor = new Extractor({ markerNames: [ "@ngTranslate" ] })
```
Will extract the following string:
```js
const myString = /* @ngTranslate */ "This will be extracted"
```