### PR TITLE
Fix extract comments with typescript files

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -53,7 +53,7 @@ function walkJs(node, fn, parentComment) {
         if (node && node.leadingComments) {
             parentComment = node;
         } else if (node && node.comments) {
-            parentComment = {leadingComments: node.comments};
+            parentComment = { leadingComments: node.comments };
         }
 
         if (typeof obj === 'object') {

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -317,7 +317,7 @@ var Extractor = (function () {
                 self.extractHtml(reference.file, node.value.raw, line);
             }
             if (str || singular) {
-                var leadingComments = node.leadingComments || (parentComment ? parentComment.leadingComments : []);
+                var leadingComments = node.leadingComments || node.comments || (parentComment ? parentComment.leadingComments : []);
                 leadingComments.forEach(function (comment) {
                     if (comment.value.match(/^\/ .*/)) {
                         extractedComments.push(comment.value.replace(/^\/ /, ''));

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -52,7 +52,10 @@ function walkJs(node, fn, parentComment) {
         var obj = node[key];
         if (node && node.leadingComments) {
             parentComment = node;
+        } else if (node && node.comments) {
+            parentComment = {leadingComments: node.comments};
         }
+
         if (typeof obj === 'object') {
             walkJs(obj, fn, parentComment);
         }
@@ -194,6 +197,7 @@ var Extractor = (function () {
             if (extension === 'ts' || extension === 'tsx') {
                 syntax = tsParser.parse(src, {
                     sourceType: 'module',
+                    comment: true,
                     ecmaFeatures: {
                         jsx: true
                     }

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -48,12 +48,16 @@ function comments2String(comments) {
 function walkJs(node, fn, parentComment) {
     fn(node, parentComment);
 
+    // Handle ts comments
+    if (node && node.comments) {
+        parentComment = node;
+        parentComment.comments.reverse();
+    }
+
     for (var key in node) {
         var obj = node[key];
         if (node && node.leadingComments) {
             parentComment = node;
-        } else if (node && node.comments) {
-            parentComment = { leadingComments: node.comments };
         }
 
         if (typeof obj === 'object') {
@@ -317,12 +321,29 @@ var Extractor = (function () {
                 self.extractHtml(reference.file, node.value.raw, line);
             }
             if (str || singular) {
-                var leadingComments = node.leadingComments || node.comments || (parentComment ? parentComment.leadingComments : []);
-                leadingComments.forEach(function (comment) {
-                    if (comment.value.match(/^\/ .*/)) {
-                        extractedComments.push(comment.value.replace(/^\/ /, ''));
-                    }
-                });
+                var leadingComments = node.leadingComments || (parentComment ? parentComment.leadingComments : []);
+                if (leadingComments) {
+                    leadingComments.forEach(function (comment) {
+                        if (comment.value.match(/^\/ .*/)) {
+                            extractedComments.push(comment.value.replace(/^\/ /, ''));
+                        }
+                    });
+                }
+
+                // Handle ts comments
+                if (parentComment.comments) {
+                    var commentFound = 0;
+                    parentComment.comments.forEach(function (comment) {
+                        if (comment.type === 'Line' &&
+                            comment.loc.start.line === (reference.location.start.line - commentFound - 1) &&
+                            comment.value.match(/^\/ .*/)) {
+                            commentFound++;
+                            extractedComments.push(comment.value.replace(/^\/ /, ''));
+                        }
+                    });
+                    extractedComments.reverse();
+                }
+
                 if (str) {
                     self.addString(reference, str, plural, comments2String(extractedComments), context);
                 } else if (singular) {

--- a/test/extract_comments.js
+++ b/test/extract_comments.js
@@ -52,6 +52,41 @@ describe('Extracting comments', function () {
         assert.deepEqual(i[7].extractedComments, ['gettextCatalog(gettext) inside array']);
     });
 
+    it('works on Typescript', function () {
+        var files = [
+            'test/fixtures/comments.ts'
+        ];
+        var catalog = testExtract(files);
+
+        var i = catalog.items;
+
+        assert.equal(i.length, 8);
+
+        assert.equal(i[0].msgid, '0: Translate this');
+        assert.deepEqual(i[0].extractedComments, ['This is a comment']);
+
+        assert.equal(i[1].msgid, '1: Two Part Comment');
+        assert.deepEqual(i[1].extractedComments, ['This is two part comment, Second part']);
+
+        assert.equal(i[2].msgid, '2: No comment');
+        assert.deepEqual(i[2].extractedComments, []);
+
+        assert.equal(i[3].msgid, '3: Bird');
+        assert.deepEqual(i[3].extractedComments, ['Plural Comments']);
+
+        assert.equal(i[4].msgid, '4: gettextCatalog.getString comment');
+        assert.deepEqual(i[4].extractedComments, ['gettextCatalog.getString() comment']);
+
+        assert.equal(i[5].msgid, '5: gettext inside array');
+        assert.deepEqual(i[5].extractedComments, ['gettext inside array']);
+
+        assert.equal(i[6].msgid, '6: gettextCatalog inside array');
+        assert.deepEqual(i[6].extractedComments, ['gettextCatalog inside array']);
+
+        assert.equal(i[7].msgid, '7: gettextCatalog(gettext) inside array');
+        assert.deepEqual(i[7].extractedComments, ['gettextCatalog(gettext) inside array']);
+    });
+
     it('merges duplicate comments', function () {
         var files = [
             'test/fixtures/duplicate-comments.html'

--- a/test/fixtures/comments.ts
+++ b/test/fixtures/comments.ts
@@ -1,0 +1,33 @@
+angular.module("myApp").controller("helloController", (gettext, gettextCatalog) => {
+    /// This is a comment
+    let myString0 = gettext("0: Translate this");
+
+    /// This is two part comment
+    /// Second part
+    let myString1 = gettext("1: Two Part Comment");
+
+    /**
+     * Please ignore this comment ///gettext
+     Thank You
+     */
+    let myString2 = gettext("2: No comment");
+
+    /// Plural Comments
+    let myString3 = gettextCatalog.getPlural(2, "3: Bird", "Birds");
+
+    /// gettextCatalog.getString() comment
+    let myString4 = gettextCatalog.getString("4: gettextCatalog.getString comment");
+
+    let array = [
+        /// gettext inside array
+        gettext('5: gettext inside array'),
+
+        /// gettextCatalog inside array
+        gettextCatalog.getString('6: gettextCatalog inside array'),
+
+        /// gettextCatalog(gettext) inside array
+        gettextCatalog.getString(gettext('7: gettextCatalog(gettext) inside array'))
+    ];
+
+    /// Comment with no translations, ignore this comment too
+});


### PR DESCRIPTION
Hi, 
Currently, we can't extract comments from typescript files, `tsParser.parse(...)` is missing the `comment: true` option.
Moreover, comments in AST are not stored in a `leadingComments` attribute, but in a `comments` attribute with `typescript-eslint-parser`
Would be great to have it fixed! 