### PR TITLE
Extract the value of the attribute first if != translate

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -409,13 +409,27 @@ var Extractor = (function () {
                     return;
                 }
 
+                /**
+                 * Extract the value, default translate filter behavior
+                 * else if it is an attribute we need to get its value first
+                 * @param  {String} attr Key name
+                 * @param  {Node} node
+                 * @return {String}
+                 */
+                function extractValue(attr, node) {
+                    if (attr === 'translate') {
+                        return node.html() || getAttr(attr) || '';
+                    }
+                    return getAttr(attr) || node.html() || '';
+                }
+
                 for (var attr in node.attr()) {
                     attr = attr.replace(/^data-/, '');
 
                     if (possibleAttributes.indexOf(attr) > -1) {
                         var attrValue = extracted[attr];
-                        str = node.html(); // this shouldn't be necessary, but it is
-                        self.addString(reference(n.startIndex), str || getAttr(attr) || '', attrValue.plural, attrValue.extractedComment, attrValue.context);
+                        str = extractValue(attr, node);
+                        self.addString(reference(n.startIndex), str, attrValue.plural, attrValue.extractedComment, attrValue.context);
                     } else if (matches = self.noDelimRegex.exec(getAttr(attr))) {
                         str = matches[2].replace(/\\\'/g, '\'');
                         self.addString(reference(n.startIndex), str);

--- a/package.json
+++ b/package.json
@@ -24,8 +24,9 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "~0.4.4",
+    "grunt": "^0.4.5",
     "grunt-bump": "0.0.13",
+    "grunt-cli": "^1.2.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-jshint": "~0.11.2",
     "grunt-contrib-watch": "~0.6.1",

--- a/test/extract.js
+++ b/test/extract.js
@@ -18,6 +18,19 @@ describe('Extract', function () {
         assert.deepEqual(catalog.items[0].references, ['test/fixtures/single.html:3', 'test/fixtures/single.html:4']);
     });
 
+    it('Extracts attributes from the view', function () {
+        var files = [
+            'test/fixtures/single.html'
+        ];
+        var catalog = testExtract(files, {
+            attributes: ['custom-translate']
+        });
+        assert.equal(catalog.items.length, 2);
+        assert.equal(catalog.items[1].msgid, 'monique');
+        assert.equal(catalog.items[1].msgstr, '');
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/single.html:5']);
+    });
+
     it('Merges multiple views into one .pot', function () {
         var files = [
             'test/fixtures/single.html',

--- a/test/fixtures/single.html
+++ b/test/fixtures/single.html
@@ -2,5 +2,6 @@
     <body>
         <h1 translate>Hello!</h1>
         <p translate>Hello!</p>
+        <b custom-translate="monique">polo</b>
     </body>
 </html>


### PR DESCRIPTION
Ex: when we define a custom attribute for a tooltip we can do:

```html
<span custom-tooltip-translate="Allez la France"><i class="fa fa-flag-france"></i></span>
```

When we extract the translations we want to extract the key `Allez la France`, that's what we have via this fix. Today we have `<i class="fa fa-flag-france"></i>`.
I added a test for this use case too.

:warning: this won't change the current behavior for `translate`.


