### PR TITLE
Fix ts extract support

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -198,7 +198,16 @@ var Extractor = (function () {
         var syntax;
         var extension = filename.split('.').pop();
         try {
-            if (extension === 'ts' || extension === 'tsx') {
+            if (extension === 'ts') {
+	            syntax = tsParser.parse(src, {
+		            sourceType: 'module',
+		            comment: true,
+		            ecmaFeatures: {
+			            jsx: false
+		            }
+	            });
+            }
+            else if (extension === 'tsx') {
                 syntax = tsParser.parse(src, {
                     sourceType: 'module',
                     comment: true,

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -199,15 +199,14 @@ var Extractor = (function () {
         var extension = filename.split('.').pop();
         try {
             if (extension === 'ts') {
-	            syntax = tsParser.parse(src, {
-		            sourceType: 'module',
-		            comment: true,
-		            ecmaFeatures: {
-			            jsx: false
-		            }
-	            });
-            }
-            else if (extension === 'tsx') {
+                syntax = tsParser.parse(src, {
+                    sourceType: 'module',
+                    comment: true,
+                    ecmaFeatures: {
+                        jsx: false
+                    }
+                });
+            } else if (extension === 'tsx') {
                 syntax = tsParser.parse(src, {
                     sourceType: 'module',
                     comment: true,

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -198,20 +198,12 @@ var Extractor = (function () {
         var syntax;
         var extension = filename.split('.').pop();
         try {
-            if (extension === 'ts') {
+            if (extension === 'ts' || extension === 'tsx') {
                 syntax = tsParser.parse(src, {
                     sourceType: 'module',
                     comment: true,
                     ecmaFeatures: {
-                        jsx: false
-                    }
-                });
-            } else if (extension === 'tsx') {
-                syntax = tsParser.parse(src, {
-                    sourceType: 'module',
-                    comment: true,
-                    ecmaFeatures: {
-                        jsx: true
+                        jsx: extension === 'tsx'
                     }
                 });
             } else {

--- a/test/extract_extensions.js
+++ b/test/extract_extensions.js
@@ -114,14 +114,18 @@ describe('Extracting files with different extensions', function () {
         ];
         var catalog =  testExtract(files);
 
-        assert.equal(catalog.items.length, 2);
-        assert.equal(catalog.items[0].msgid, 'Hello');
+        assert.equal(catalog.items.length, 3);
+        assert.equal(catalog.items[0].msgid, 'Casted');
         assert.equal(catalog.items[0].msgstr, '');
-        assert.deepEqual(catalog.items[0].references, ['test/fixtures/ts.ts:2']);
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/ts.ts:6']);
 
-        assert.equal(catalog.items[1].msgid, 'One\nTwo\nThree');
+        assert.equal(catalog.items[1].msgid, 'Hello');
         assert.equal(catalog.items[1].msgstr, '');
-        assert.deepEqual(catalog.items[1].references, ['test/fixtures/ts.ts:3']);
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/ts.ts:2']);
+
+        assert.equal(catalog.items[2].msgid, 'One\nTwo\nThree');
+        assert.equal(catalog.items[2].msgstr, '');
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/ts.ts:3']);
     });
 
     it('supports TypeScript .tsx files', function () {

--- a/test/fixtures/ts.ts
+++ b/test/fixtures/ts.ts
@@ -3,5 +3,6 @@ angular.module("myApp").controller("helloController", (gettext) => {
     var longString: string = gettext(`One
 Two
 Three`);
+    var castedVar: any = <any> gettext("Casted");
     gettext(); // Should be ignored.
 });


### PR DESCRIPTION
Since version 2.3.7 ts extract support is broken, reason beeing the ecmaFeatures jsx set to true also in case of ts extension.
Added an if case to set this to false for ts, and leave it to true for jsx.