### PR TITLE
updated dependencies to also support TypeScript 3

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -3,7 +3,7 @@
 var cheerio = require('cheerio');
 var Po = require('pofile');
 var babylon = require('babylon');
-var tsParser = require('typescript-eslint-parser');
+var tsParser = require('@typescript-eslint/parser');
 var search = require('binary-search');
 var _ = require('lodash');
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.4",
-    "grunt-bump": "0.0.13",
+    "grunt-bump": "^0.8.0",
     "grunt-contrib-clean": "~0.6.0",
     "grunt-contrib-jshint": "~0.11.2",
     "grunt-contrib-watch": "~0.6.1",
@@ -38,12 +38,13 @@
     "gettext"
   ],
   "dependencies": {
+    "@typescript-eslint/parser": "^1.3.0",
     "babylon": "^6.11.4",
     "binary-search": "^1.2.0",
-    "cheerio": "~0.19.0",
+    "cheerio": "^0.22.0",
+    "eslint": "^5.14.1",
     "lodash": "^4.17.5",
     "pofile": "~1.0.0",
-    "typescript": "~2.3.2",
-    "typescript-eslint-parser": "^3.0.0"
+    "typescript": "~3.2.4"
   }
 }


### PR DESCRIPTION
relates to https://github.com/rubenv/angular-gettext-tools/issues/192

this was actually quite easy, just a drop in replacement.

on a side note you might want to consider to commit the package-lock.json file