### PR TITLE
fix: align versions in package*json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-gettext-tools",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Right now there is a difference in version (for this package) between `package.json` and `package-lock.json`.  I think proper way to change version as of now is to use `npm version [major|minor|patch]` command

<img width="1065" alt="Screen Shot 2019-07-09 at 12 54 51" src="https://user-images.githubusercontent.com/597016/60878649-c2bcaa00-a248-11e9-824c-f4321d3c0f20.png">
