### PR TITLE
feat: add option to not skip fuzzy strings

### DIFF
--- a/lib/compile.js
+++ b/lib/compile.js
@@ -56,6 +56,7 @@ var Compiler = (function () {
     function Compiler(options) {
         this.options = _.extend({
             format: 'javascript',
+            ignoreFuzzyString: true,
             module: 'gettext'
         }, options);
     }
@@ -108,6 +109,7 @@ var Compiler = (function () {
 
     Compiler.prototype.convertPo = function (inputs) {
         var format = formats[this.options.format];
+        var ignoreFuzzyString = this.options.ignoreFuzzyString;
         var locales = [];
 
         inputs.forEach(function (input) {
@@ -133,7 +135,10 @@ var Compiler = (function () {
                     msgid = msgid.replace( unconvertedEntityPattern, convertedEntity );
                 }
 
-                if (item.msgstr[0].length > 0 && !item.flags.fuzzy && !item.obsolete) {
+                var nonEmptyUpToDateStr = item.msgstr[0].length > 0 && !item.obsolete;
+                var useNonFuzzyStrOnly = ignoreFuzzyString && !item.flags.fuzzy;
+
+                if (nonEmptyUpToDateStr && (useNonFuzzyStrOnly || !ignoreFuzzyString)) {
                     if (!strings[msgid]) {
                         strings[msgid] = {};
                     }

--- a/test/compile.js
+++ b/test/compile.js
@@ -193,6 +193,20 @@ describe('Compile', function () {
         });
     });
 
+    it('Intentionally does not ignore fuzzy strings', function () {
+        var files = ['test/fixtures/fuzzy.po'];
+        var output = testCompile(files, {
+            format: 'json',
+            ignoreFuzzyString: false
+        });
+        var data = JSON.parse(output);
+
+        assert.deepEqual(data.nl, {
+            'Hello!': 'Dag!',
+            'This is a test': 'Dit is een test'
+        });
+    });
+
     it('Can output multiple inputs to single JSON', function () {
         var files = ['test/fixtures/fr.po', 'test/fixtures/depth/fr.po'];
         var output = testCompile(files, {


### PR DESCRIPTION
In my case final JSON dictionary is "composed" from two sources: `.po` file that came from translator and another `.po` file (with just extracted strings) filled with auto-translated strings. So I need dedicated option to deal with this case. Code is written in manner that does not require any changes for existing users