### PR TITLE
Added translate="no" logic

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -414,6 +414,10 @@ var Extractor = (function () {
                  * @return {String}
                  */
                 function extractValue(attr, node) {
+                    if (node.attr().hasOwnProperty('translate') && node.attr('translate') === 'no') {
+                        return '';
+                    }
+
                     if (attr === 'translate') {
                         return node.html() || getAttr(attr) || '';
                     }


### PR DESCRIPTION
## What?
Logic to exclude translate="no" tags from extract command scope

## Why?
So far google chrome supports translate="no" attribute for the content which is not going to be translated by automatic google translate plugin or any other translation. In this PR you can find a logic to do such a thing. Proof:
https://cloud.google.com/translate/faq#technical_questions

## Testing / Proof
Run gulp gettext:extract on the template with the translate="no" attribute

ping @rubenv 
