### PR TITLE
Make the filter name configurable independently of the attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ All options and defaults are displayed below:
     "attribute": "translate",
     "attributes": [],
     "lineNumbers": true,
+    "filterName": "translate",
     "format": "javascript",
     "defaultLanguage": false,
     "requirejs": false

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -100,6 +100,7 @@ var Extractor = (function () {
             moduleMethodPlural: 'getPlural',
             attribute: 'translate',
             attributes: [],
+            filterName: null,
             lineNumbers: true,
             extensions: {
                 htm: 'html',
@@ -120,9 +121,14 @@ var Extractor = (function () {
         this.options.markerNames.unshift(this.options.markerName);
         this.options.attributes.unshift(this.options.attribute);
 
+        if (!this.options.filterName) {
+            // If the filter name is not specified, assume the specified attribute is also the filter name
+            this.options.filterName = this.options.attribute;
+        }
+
         this.strings = {};
-        this.attrRegex = mkAttrRegex(this.options.startDelim, this.options.endDelim, this.options.attribute);
-        this.noDelimRegex = mkAttrRegex('', '', this.options.attribute);
+        this.attrRegex = mkAttrRegex(this.options.startDelim, this.options.endDelim, this.options.filterName);
+        this.noDelimRegex = mkAttrRegex('', '', this.options.filterName);
     }
 
     Extractor.isValidStrategy = function (strategy) {

--- a/test/extract_custom_filter_standard_attribute.js
+++ b/test/extract_custom_filter_standard_attribute.js
@@ -1,0 +1,121 @@
+'use strict';
+
+var assert = require('assert');
+var testExtract = require('./utils').testExtract;
+
+describe('Extracting custom filters but standard attribute', function () {
+
+    it('works for the simple case', function () {
+        var files = [
+            'test/fixtures/filter-custom-standard-attribute.html'
+        ];
+        var catalog = testExtract(files, {
+            filterName: 'trans'
+        });
+
+        assert.equal(catalog.items.length, 3);
+
+        assert.equal(catalog.items[0].msgid, 'Hello');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.equal(catalog.items[0].references.length, 1);
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/filter-custom-standard-attribute.html:4']);
+
+        assert.equal(catalog.items[1].msgid, 'Label');
+        assert.equal(catalog.items[1].msgstr, '');
+        assert.equal(catalog.items[1].references.length, 1);
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/filter-custom-standard-attribute.html:3']);
+
+        assert.equal(catalog.items[2].msgid, 'Second');
+        assert.equal(catalog.items[2].msgstr, '');
+        assert.equal(catalog.items[2].references.length, 1);
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/filter-custom-standard-attribute.html:5']);
+    });
+
+    it('works for concatenated filter strings', function () {
+        var files = [
+            'test/fixtures/multifilter-custom-standard-attribute.html'
+        ];
+        var catalog = testExtract(files, {
+            filterName: 'trans'
+        });
+
+        assert.equal(catalog.items.length, 3);
+
+        assert.equal(catalog.items[0].msgid, 'Hello');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.equal(catalog.items[0].references.length, 1);
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/multifilter-custom-standard-attribute.html:4']);
+
+        assert.equal(catalog.items[1].msgid, 'Label');
+        assert.equal(catalog.items[1].msgstr, '');
+        assert.equal(catalog.items[1].references.length, 1);
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/multifilter-custom-standard-attribute.html:3']);
+
+        assert.equal(catalog.items[2].msgid, 'World');
+        assert.equal(catalog.items[2].msgstr, '');
+        assert.equal(catalog.items[2].references.length, 1);
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/multifilter-custom-standard-attribute.html:5']);
+    });
+
+    it('works on filter strings using escaped quotes', function () {
+        var files = [
+            'test/fixtures/escaped_quotes-custom-standard-attribute.html'
+        ];
+        var catalog = testExtract(files, {
+            filterName: 'trans'
+        });
+
+        assert.equal(catalog.items.length, 3);
+
+        assert.equal(catalog.items[0].msgid, 'Hello');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.equal(catalog.items[0].references.length, 1);
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/escaped_quotes-custom-standard-attribute.html:4']);
+
+        assert.equal(catalog.items[1].msgid, 'Label');
+        assert.equal(catalog.items[1].msgstr, '');
+        assert.equal(catalog.items[1].references.length, 1);
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/escaped_quotes-custom-standard-attribute.html:3']);
+
+        assert.equal(catalog.items[2].msgid, 'World');
+        assert.equal(catalog.items[2].msgstr, '');
+        assert.equal(catalog.items[2].references.length, 1);
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/escaped_quotes-custom-standard-attribute.html:5']);
+    });
+
+    it('works on filter strings in multiple expression attributes', function () {
+        var files = [
+            'test/fixtures/filter-in-multiple-expression-attributes-custom-standard-attribute.html'
+        ];
+        var catalog = testExtract(files, {
+            filterName: 'trans'
+        });
+
+        assert.equal(catalog.items.length, 5);
+
+        assert.equal(catalog.items[0].msgid, 'Label');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.equal(catalog.items[0].references.length, 1);
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/filter-in-multiple-expression-attributes-custom-standard-attribute.html:3']);
+
+        assert.equal(catalog.items[1].msgid, 'expr1');
+        assert.equal(catalog.items[1].msgstr, '');
+        assert.equal(catalog.items[1].references.length, 1);
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/filter-in-multiple-expression-attributes-custom-standard-attribute.html:4']);
+
+        assert.equal(catalog.items[2].msgid, 'expr2');
+        assert.equal(catalog.items[2].msgstr, '');
+        assert.equal(catalog.items[2].references.length, 1);
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/filter-in-multiple-expression-attributes-custom-standard-attribute.html:4']);
+
+        assert.equal(catalog.items[3].msgid, 'expr3');
+        assert.equal(catalog.items[3].msgstr, '');
+        assert.equal(catalog.items[3].references.length, 1);
+        assert.deepEqual(catalog.items[3].references, ['test/fixtures/filter-in-multiple-expression-attributes-custom-standard-attribute.html:4']);
+
+        assert.equal(catalog.items[4].msgid, 'expr4');
+        assert.equal(catalog.items[4].msgstr, '');
+        assert.equal(catalog.items[4].references.length, 1);
+        assert.deepEqual(catalog.items[4].references, ['test/fixtures/filter-in-multiple-expression-attributes-custom-standard-attribute.html:4']);
+    });
+});

--- a/test/fixtures/escaped_quotes-custom-standard-attribute.html
+++ b/test/fixtures/escaped_quotes-custom-standard-attribute.html
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <label translate>Label</label>
+        <input type="text" placeholder="{{&quot;Hello&quot;|trans}}" />
+        <input type="text" placeholder="{{&#39;World&#39;|trans}}" />
+    </body>
+</html>

--- a/test/fixtures/filter-custom-standard-attribute.html
+++ b/test/fixtures/filter-custom-standard-attribute.html
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <label translate>Label</label>
+        <input type="text" placeholder="{{'Hello'|trans}}" />
+        <span>{{'Second'|trans}}</span>
+    </body>
+</html>

--- a/test/fixtures/filter-in-multiple-expression-attributes-custom-standard-attribute.html
+++ b/test/fixtures/filter-in-multiple-expression-attributes-custom-standard-attribute.html
@@ -1,0 +1,6 @@
+<html>
+    <body>
+        <label translate>Label</label>
+        <my-directive expr1="'expr1' | trans" expr2="'expr2' | trans" expr3="'expr3' | trans" expr4="'expr4' | trans"></my-directive>
+    </body>
+</html>

--- a/test/fixtures/multifilter-custom-standard-attribute.html
+++ b/test/fixtures/multifilter-custom-standard-attribute.html
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <label translate>Label</label>
+        <input type="text" placeholder="{{'Hello'|trans|lowercase}}" />
+        <span>{{'World'|trans|lowercase}}</span>
+    </body>
+</html>


### PR DESCRIPTION
We had a case where we needed to use a custom filter, but continue to use the regular `angular-gettext` directive. So we need to configure the filter name independently of the attributes. This PR does that.

Projects using a custom attribute and filter will need to set the `filterName` option accordingly, so this is a breaking changes.