### PR TITLE
Add plural marker name support to extraction.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ All options and defaults are displayed below:
     "endDelim": "}}",
     "markerName": "gettext",
     "markerNames": [],
+    "markerNamePlural": null,
+    "markerNamesPlural": [],
     "moduleName": "gettextCatalog",
     "moduleMethodString": "getString",
     "moduleMethodPlural": "getPlural",

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -95,6 +95,8 @@ var Extractor = (function () {
             endDelim: '}}',
             markerName: 'gettext',
             markerNames: [],
+            markerNamePlural: null,
+            markerNamesPlural: [],
             moduleName: 'gettextCatalog',
             moduleMethodString: 'getString',
             moduleMethodPlural: 'getPlural',
@@ -119,6 +121,10 @@ var Extractor = (function () {
             postProcess: function (po) {}
         }, options);
         this.options.markerNames.unshift(this.options.markerName);
+        if (this.options.markerNamePlural) {
+            this.options.markerNamesPlural.unshift(this.options.markerNamePlural);
+        }
+
         this.options.attributes.unshift(this.options.attribute);
 
         if (!this.options.filterName) {
@@ -253,6 +259,18 @@ var Extractor = (function () {
                 node.arguments.length;
         }
 
+        function isGettextPlural(node) {
+            return node !== null &&
+                node.type === 'CallExpression' &&
+                node.callee !== null &&
+                (self.options.markerNamesPlural.indexOf(node.callee.name) > -1 || (
+                    node.callee.property &&
+                    self.options.markerNamesPlural.indexOf(node.callee.property.name) > -1
+                )) &&
+                node.arguments !== null &&
+                node.arguments.length;
+        }
+
         function isGetString(node) {
             return node !== null &&
                 node.type === 'CallExpression' &&
@@ -318,7 +336,7 @@ var Extractor = (function () {
                 if (node.arguments[2]) {
                     context = getJSExpression(node.arguments[2]);
                 }
-            } else if (isGetPlural(node)) {
+            } else if (isGettextPlural(node) || isGetPlural(node)) {
                 singular = getJSExpression(node.arguments[1]);
                 plural = getJSExpression(node.arguments[2]);
                 if (node.arguments[4]) {

--- a/test/extract.js
+++ b/test/extract.js
@@ -262,6 +262,21 @@ describe('Extract', function () {
         assert.deepEqual(catalog.items[0].references, ['test/fixtures/custom_marker_name.js:4']);
     });
 
+    it('Can customize the plural marker name', function () {
+        var files = [
+            'test/fixtures/custom_marker_name_plural.js'
+        ];
+        var catalog = testExtract(files, {
+            markerNamePlural: '_n'
+        });
+
+        assert.equal(catalog.items.length, 1);
+        assert.equal(catalog.items[0].msgid, 'Hello custom singular');
+        assert.equal(catalog.items[0].msgid_plural, 'Hello custom plural');
+        assert.deepEqual(catalog.items[0].msgstr, ['', '']);
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/custom_marker_name_plural.js:4']);
+    });
+
     it('Can customize multiple marker name functions', function () {
         var files = [
             'test/fixtures/custom_marker_names.js'
@@ -281,6 +296,29 @@ describe('Extract', function () {
         assert.equal(catalog.items[2].msgid, 'Hello second custom');
         assert.equal(catalog.items[2].msgstr, '');
         assert.deepEqual(catalog.items[2].references, ['test/fixtures/custom_marker_names.js:7']);
+    });
+
+    it('Can customize multiple plural marker name functions', function () {
+        var files = [
+            'test/fixtures/custom_marker_names_plural.js'
+        ];
+        var catalog = testExtract(files, { markerNamesPlural: ['showErrors', 'showSuccesses'] });
+
+        assert.equal(catalog.items.length, 3);
+
+        assert.equal(catalog.items[0].msgid, 'Hello default');
+        assert.equal(catalog.items[0].msgstr, '');
+        assert.deepEqual(catalog.items[0].references, ['test/fixtures/custom_marker_names_plural.js:2']);
+
+        assert.equal(catalog.items[1].msgid, 'Hello first custom singular');
+        assert.equal(catalog.items[1].msgid_plural, 'Hello first custom plural');
+        assert.deepEqual(catalog.items[1].msgstr, ['', '']);
+        assert.deepEqual(catalog.items[1].references, ['test/fixtures/custom_marker_names_plural.js:6']);
+
+        assert.equal(catalog.items[2].msgid, 'Hello second custom singular');
+        assert.equal(catalog.items[2].msgid_plural, 'Hello second custom plural');
+        assert.deepEqual(catalog.items[2].msgstr, ['', '']);
+        assert.deepEqual(catalog.items[2].references, ['test/fixtures/custom_marker_names_plural.js:7']);
     });
 
     it('Can post-process the catalog', function () {

--- a/test/fixtures/custom_marker_name_plural.js
+++ b/test/fixtures/custom_marker_name_plural.js
@@ -1,0 +1,5 @@
+window._n = function(n, str, plural) { return n === 1 ? str : plursal; };
+
+angular.module("myApp").controller("customController", function (gettext) {
+    var myString = _n(1, "Hello custom singular", "Hello custom plural");
+});

--- a/test/fixtures/custom_marker_names_plural.js
+++ b/test/fixtures/custom_marker_names_plural.js
@@ -1,0 +1,11 @@
+angular.module("myApp").controller("customController", function (gettext) {
+    var myString = gettext("Hello default");
+    // Should be ignored.
+    gettext();
+
+    showErrors(1, "Hello first custom singular", "Hello first custom plural");
+    showSuccesses(1, "Hello second custom singular", "Hello second custom plural");
+
+    function showError(str) { }
+    function showSuccess(str) { }
+});


### PR DESCRIPTION
Add support for specifying the options `markerNamePlural` and/or `markerNamesPlural`, which will be used to extract strings from matching function calls. This allows using a regular function (as opposed to a method) for pluralizable catalog messages.

If the options are not specified, the extractor continues to work as before. Includes unit tests to cover the new behavior.