### PR TITLE
Extract isGetString: add option moduleMethodStringArgumentIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ All options and defaults are displayed below:
     "markerNamesPlural": [],
     "moduleName": "gettextCatalog",
     "moduleMethodString": "getString",
+    "moduleMethodStringArgumentIndex": 0,
     "moduleMethodPlural": "getPlural",
     "attribute": "translate",
     "attributes": [],

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -99,6 +99,7 @@ var Extractor = (function () {
             markerNamesPlural: [],
             moduleName: 'gettextCatalog',
             moduleMethodString: 'getString',
+            moduleMethodStringArgumentIndex: 0,
             moduleMethodPlural: 'getPlural',
             attribute: 'translate',
             attributes: [],
@@ -331,8 +332,13 @@ var Extractor = (function () {
                 })()
             };
 
-            if (isGettext(node) || isGetString(node)) {
+            if (isGettext(node)) {
                 str = getJSExpression(node.arguments[0]);
+                if (node.arguments[2]) {
+                    context = getJSExpression(node.arguments[2]);
+                }
+            } else if (isGetString(node)) {
+                str = getJSExpression(node.arguments[self.options.moduleMethodStringArgumentIndex]);
                 if (node.arguments[2]) {
                     context = getJSExpression(node.arguments[2]);
                 }


### PR DESCRIPTION
### Real usage : 

Extract for the method `gettextCatalog.getStringForLanguage`. The text is the second argument

```
gettextCatalog.getStringForLanguage(
          lang,
          'text'
        )
```

```
const gettextExtractor = new Extractor({
  moduleMethodString: "getStringForLanguage",
  moduleMethodStringArgumentIndex: 1
})
```
